### PR TITLE
Refactor SSL code

### DIFF
--- a/agent/agent.js
+++ b/agent/agent.js
@@ -26,7 +26,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed !== false;
+const ssl_self_signed = config.ssl_self_signed === false;
 const server = config.web_connect;
 const server_port = config.server_port;
 const agent_port = config.agent_port;

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -12,6 +12,7 @@ const getos = require('picluster-getos');
 const async = require('async');
 const exec = require('child-process-promise').exec;
 const sysinfo = require('systeminformation');
+
 const config = process.env.PICLUSTER_CONFIG ? JSON.parse(fs.readFileSync(process.env.PICLUSTER_CONFIG, 'utf8')) : JSON.parse(fs.readFileSync('../config.json', 'utf8'));
 const app = express();
 
@@ -24,6 +25,7 @@ app.use(bodyParser());
 const upload = multer({
   dest: '../'
 });
+const scheme = config.ssl ? 'https://' : 'http://';
 const server = config.web_connect;
 const server_port = config.server_port;
 const agent_port = config.agent_port;
@@ -121,7 +123,7 @@ if (config.autostart_containers) {
   console.log('Starting all the containers.....');
 
   const options = {
-    url : `${scheme}${server}:${server_port}/start?token=${token}&container=*`
+    url: `${scheme}${server}:${server_port}/start?token=${token}&container=*`
   };
 
   if (config.ssl_self_signed) {

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -26,6 +26,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
+const ssl_self_signed = config.ssl_self_signed ? 'false' : 'true';
 const server = config.web_connect;
 const server_port = config.server_port;
 const agent_port = config.agent_port;
@@ -123,12 +124,9 @@ if (config.autostart_containers) {
   console.log('Starting all the containers.....');
 
   const options = {
-    url: `${scheme}${server}:${server_port}/start?token=${token}&container=*`
+    url: `${scheme}${server}:${server_port}/start?token=${token}&container=*`,
+    rejectUnauthorized: ssl_self_signed
   };
-
-  if (config.ssl_self_signed) {
-    options['rejectUnauthorized'] = 'false';
-  }
 
   request.get(options).on('error', e => {
     console.error(e);
@@ -170,6 +168,7 @@ function send_ping() {
 
     const options = {
       url: `${scheme}${vip_slave}:${agent_port}/pong`,
+      rejectUnauthorized: ssl_self_signed,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -177,10 +176,6 @@ function send_ping() {
       },
       body: token_body
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => {
       let found_vip = false;

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -26,7 +26,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed ? false : true;
+const ssl_self_signed = config.ssl_self_signed !== false;
 const server = config.web_connect;
 const server_port = config.server_port;
 const agent_port = config.agent_port;

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -187,7 +187,6 @@ function send_ping() {
 
       if ((error || response.statusCode !== '200')) {
         const cmd = ip_add_command;
-        // Console.log("\nUnable to connect to: " + vip_slave + ". Bringing up VIP on this host.");
         exec(cmd).then(noop).catch(noop);
       } else {
         const interfaces = require('os').networkInterfaces();

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -26,7 +26,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed ? 'false' : 'true';
+const ssl_self_signed = config.ssl_self_signed ? false : true;
 const server = config.web_connect;
 const server_port = config.server_port;
 const agent_port = config.agent_port;

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -127,7 +127,7 @@ if (config.autostart_containers) {
   };
 
   if (config.ssl_self_signed) {
-    options.rejectUnauthorized = 'false';
+    options['rejectUnauthorized'] = 'false';
   }
 
   request.get(options).on('error', e => {
@@ -179,7 +179,7 @@ function send_ping() {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => {

--- a/server/server.js
+++ b/server/server.js
@@ -31,7 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed ? 'false' : 'true';
+const ssl_self_signed = config.ssl_self_signed ? false : true;
 const server = config.web_connect;
 const rsyslog_host = config.rsyslog_host;
 const server_port = config.server_port;

--- a/server/server.js
+++ b/server/server.js
@@ -31,6 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
+const ssl_self_signed = config.ssl_self_signed ? 'false' : 'true';
 const server = config.web_connect;
 const rsyslog_host = config.rsyslog_host;
 const server_port = config.server_port;
@@ -102,12 +103,9 @@ function automatic_heartbeat() {
   if (config.automatic_heartbeat.indexOf('enabled') > -1) {
     setTimeout(() => {
       const options = {
-        url: `${scheme}${server}:${server_port}/hb?token=${token}`
+        url: `${scheme}${server}:${server_port}/hb?token=${token}`,
+        rejectUnauthorized: ssl_self_signed
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-      }
 
       request.get(options).on('error', e => {
         console.error(e);
@@ -182,12 +180,9 @@ app.get('/nodes', (req, res) => {
 
       const options = {
         url: `${scheme}${node}:${agent_port}/node-status?token=${token}`,
+        rejectUnauthorized: ssl_self_signed,
         method: 'GET'
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-      }
 
       request(options, (error, response) => {
         if (error) {
@@ -249,6 +244,7 @@ app.get('/build', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/run`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -256,10 +252,6 @@ app.get('/build', (req, res) => {
           },
           body: command
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((image.indexOf('*') > -1) || key.indexOf(image) > -1) {
           request(options, (error, response) => {
@@ -307,6 +299,7 @@ app.get('/delete-image', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -314,10 +307,6 @@ app.get('/delete-image', (req, res) => {
           },
           body: command
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((image.indexOf('*') > -1) || key.indexOf(image) > -1) {
           request(options, (error, response) => {
@@ -366,16 +355,13 @@ app.get('/create', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/run`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'Content-Length': command.length
           }
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((key.indexOf(container) > -1) || (container.indexOf('*')) > -1) {
           const create_request = request(options, response => {
@@ -430,6 +416,7 @@ app.get('/start', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/run`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -437,10 +424,6 @@ app.get('/start', (req, res) => {
           },
           body: command
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
           request(options, (error, response) => {
@@ -475,6 +458,7 @@ function migrate(container, original_host, new_host, original_container_data) {
 
   const options = {
     url: `${scheme}${original_host}:${agent_port}/run`,
+    rejectUnauthorized: ssl_self_signed,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -482,10 +466,6 @@ function migrate(container, original_host, new_host, original_container_data) {
     },
     body: command
   };
-
-  if (config.ssl_self_signed) {
-    options['rejectUnauthorized'] = 'false';
-  }
 
   request(options, error => {
     if (error) {
@@ -498,6 +478,7 @@ function migrate(container, original_host, new_host, original_container_data) {
 
       const options = {
         url: `${scheme}${new_host}:${agent_port}/run`,
+        rejectUnauthorized: ssl_self_signed,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -505,10 +486,6 @@ function migrate(container, original_host, new_host, original_container_data) {
         },
         body: command
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-      }
 
       request(options, error => {
         if (error) {
@@ -521,6 +498,7 @@ function migrate(container, original_host, new_host, original_container_data) {
 
           const options = {
             url: `${scheme}${new_host}:${agent_port}/run`,
+            rejectUnauthorized: ssl_self_signed,
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -528,10 +506,6 @@ function migrate(container, original_host, new_host, original_container_data) {
             },
             body: command
           };
-
-          if (config.ssl_self_signed) {
-            options['rejectUnauthorized'] = 'false';
-          }
 
           request(options, error => {
             if (error) {
@@ -583,6 +557,7 @@ app.get('/addhost', (req, res) => {
 
       const options = {
         url: `${scheme}${server}:${server_port}/updateconfig`,
+        rejectUnauthorized: ssl_self_signed,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -590,10 +565,6 @@ app.get('/addhost', (req, res) => {
         },
         body: new_config
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-      }
 
       request(options, error => {
         if (error) {
@@ -703,6 +674,7 @@ app.get('/rmhost', (req, res) => {
 
   const options = {
     url: `${scheme}${server}:${server_port}/updateconfig`,
+    rejectUnauthorized: ssl_self_signed,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -710,10 +682,6 @@ app.get('/rmhost', (req, res) => {
     },
     body: new_config
   };
-
-  if (config.ssl_self_signed) {
-    options['rejectUnauthorized'] = 'false';
-  }
 
   request(options, error => {
     if (error) {
@@ -787,6 +755,7 @@ app.get('/removecontainerconfig', (req, res) => {
 
     const options = {
       url: `${scheme}${server}:${server_port}/updateconfig`,
+      rejectUnauthorized: ssl_self_signed,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -794,10 +763,6 @@ app.get('/removecontainerconfig', (req, res) => {
       },
       body: new_config
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, error => {
       if (error) {
@@ -865,6 +830,7 @@ app.get('/addcontainer', (req, res) => {
 
       const options = {
         url: `${scheme}${server}:${server_port}/updateconfig`,
+        rejectUnauthorized: ssl_self_signed,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -875,13 +841,8 @@ app.get('/addcontainer', (req, res) => {
 
       const container_options = {
         url: `${scheme}${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${host}`,
-        rejectUnauthorized: 'false'
+        rejectUnauthorized: ssl_self_signed
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-        container_options['rejectUnauthorized'] = 'false';
-      }
 
       request(options, error => {
         if (error) {
@@ -986,6 +947,7 @@ app.get('/changehost', (req, res) => {
 
       const options = {
         url: `${scheme}${server}:${server_port}/updateconfig`,
+        rejectUnauthorized: ssl_self_signed,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -993,10 +955,6 @@ app.get('/changehost', (req, res) => {
         },
         body: new_config
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-      }
 
       request(options, error => {
         if (error) {
@@ -1040,6 +998,7 @@ app.get('/stop', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/run`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -1047,10 +1006,6 @@ app.get('/stop', (req, res) => {
           },
           body: command
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
           request(options, (error, response) => {
@@ -1098,6 +1053,7 @@ app.get('/delete', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/run`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -1105,10 +1061,6 @@ app.get('/delete', (req, res) => {
           },
           body: command
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
           request(options, (error, response) => {
@@ -1156,6 +1108,7 @@ app.get('/restart', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/run`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -1163,10 +1116,6 @@ app.get('/restart', (req, res) => {
           },
           body: command
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
           request(options, (error, response) => {
@@ -1214,6 +1163,7 @@ app.get('/containerlog', (req, res) => {
 
         const options = {
           url: `${scheme}${node}:${agent_port}/run`,
+          rejectUnauthorized: ssl_self_signed,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -1221,10 +1171,6 @@ app.get('/containerlog', (req, res) => {
           },
           body: command
         };
-
-        if (config.ssl_self_signed) {
-          options['rejectUnauthorized'] = 'false';
-        }
 
         if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
           request(options, (error, response) => {
@@ -1307,12 +1253,9 @@ function copyToAgents(file) {
 
       const form_options = {
         url: `${scheme}${node}:${agent_port}/receive-file`,
+        rejectUnauthorized: ssl_self_signed,
         formData
       };
-
-      if (config.ssl_self_signed) {
-        form_options['rejectUnauthorized'] = 'false';
-      }
 
       request.post(form_options, err => {
         if (!err) {
@@ -1383,6 +1326,7 @@ app.post('/exec', (req, res) => {
 
       const options = {
         url: `${scheme}${node}:${agent_port}/run`,
+        rejectUnauthorized: ssl_self_signed,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1390,10 +1334,6 @@ app.post('/exec', (req, res) => {
         },
         body: command
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-      }
 
       if (selected_node.length === 0) {
         request(options, (error, response) => {
@@ -1437,6 +1377,7 @@ app.get('/prune', (req, res) => {
 
       const options = {
         url: `${scheme}${node}:${agent_port}/run`,
+        rejectUnauthorized: ssl_self_signed,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1444,10 +1385,6 @@ app.get('/prune', (req, res) => {
         },
         body: command
       };
-
-      if (config.ssl_self_signed) {
-        options['rejectUnauthorized'] = 'false';
-      }
 
       request(options, (error, response) => {
         if (error) {
@@ -1470,12 +1407,9 @@ function move_container(container, newhost) {
 
   const options = {
     url: `${scheme}${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`,
+    rejectUnauthorized: ssl_self_signed,
     method: 'GET'
   };
-
-  if (config.ssl_self_signed) {
-    options['rejectUnauthorized'] = 'false';
-  }
 
   request(options, error => {
     if (error) {
@@ -1542,7 +1476,8 @@ function hb_check(node, container_port, container) {
       }
 
       const options = {
-        url: `${scheme}${server}:${server_port}/restart?node=${node}&container=${container}&token=${token}`
+        url: `${scheme}${server}:${server_port}/restart?node=${node}&container=${container}&token=${token}`,
+        rejectUnauthorized: ssl_self_signed
       };
 
       http.get(options).on('error', e => {
@@ -1601,12 +1536,9 @@ app.get('/rsyslog', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${rsyslog_host}:${agent_port}/rsyslog?token=${token}`
+      url: `${scheme}${rsyslog_host}:${agent_port}/rsyslog?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => {
       if (!error && response.statusCode === 200) {
@@ -1677,6 +1609,7 @@ app.get('/killvip', (req, res) => {
 
           const options = {
             url: `${scheme}${node}:${agent_port}/killvip`,
+            rejectUnauthorized: ssl_self_signed,
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -1684,10 +1617,6 @@ app.get('/killvip', (req, res) => {
             },
             body: token_body
           };
-
-          if (config.ssl_self_signed) {
-            options['rejectUnauthorized'] = 'false';
-          }
 
           request(options, error => {
             if (error) {

--- a/server/server.js
+++ b/server/server.js
@@ -624,16 +624,6 @@ app.get('/start', (req, res) => {
             },
             body: command
           };
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStarting: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else if (config.ssl && config.ssl_self_signed) {
           const options = {
             url: 'https://' + node + ':' + agent_port + '/run',
@@ -645,16 +635,6 @@ app.get('/start', (req, res) => {
             },
             body: command
           };
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStarting: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else {
           const options = {
             url: 'http://' + node + ':' + agent_port + '/run',
@@ -665,16 +645,16 @@ app.get('/start', (req, res) => {
             },
             body: command
           };
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStarting: ' + key + '\n' + results.output);
-              }
-            });
-          }
+        }
+        if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
+          request(options, (error, response) => {
+            if (error) {
+              res.end('An error has occurred.');
+            } else {
+              const results = JSON.parse(response.body);
+              addLog('\nStarting: ' + key + '\n' + results.output);
+            }
+          });
         }
       });
     });
@@ -742,6 +722,7 @@ function migrate(container, original_host, new_host, original_container_data) {
               },
               body: command
             };
+
             request(options, error => {
               if (error) {
                 addLog('An error has occurred.');
@@ -809,6 +790,7 @@ function migrate(container, original_host, new_host, original_container_data) {
               },
               body: command
             };
+
             request(options, error => {
               if (error) {
                 addLog('An error has occurred.');
@@ -873,6 +855,7 @@ function migrate(container, original_host, new_host, original_container_data) {
               },
               body: command
             };
+
             request(options, error => {
               if (error) {
                 addLog('An error has occurred.');
@@ -934,14 +917,6 @@ app.get('/addhost', (req, res) => {
           },
           body: new_config
         };
-
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            res.end('\nAdded host ' + host + ' to the configuration.');
-          }
-        });
       } else if (config.ssl && config.ssl_self_signed) {
         // Save Configuration
         const options = {
@@ -954,14 +929,6 @@ app.get('/addhost', (req, res) => {
           },
           body: new_config
         };
-
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            res.end('\nAdded host ' + host + ' to the configuration.');
-          }
-        });
       } else {
         // Save Configuration
         const options = {
@@ -973,15 +940,15 @@ app.get('/addhost', (req, res) => {
           },
           body: new_config
         };
-
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            res.end('\nAdded host ' + host + ' to the configuration.');
-          }
-        });
       }
+
+      request(options, error => {
+        if (error) {
+          res.end(error);
+        } else {
+          res.end('\nAdded host ' + host + ' to the configuration.');
+        }
+      });
     } else {
       res.end('\nError: Host already exists');
     }
@@ -1091,14 +1058,6 @@ app.get('/rmhost', (req, res) => {
       },
       body: new_config
     };
-
-    request(options, error => {
-      if (error) {
-        res.end(error);
-      } else {
-        res.end('\nAdded host ' + host + ' to the configuration.');
-      }
-    });
   } else if (config.ssl && config.ssl_self_signed) {
     // Save Configuration
     const options = {
@@ -1111,14 +1070,6 @@ app.get('/rmhost', (req, res) => {
       },
       body: new_config
     };
-
-    request(options, error => {
-      if (error) {
-        res.end(error);
-      } else {
-        res.end('\nAdded host ' + host + ' to the configuration.');
-      }
-    });
   } else {
     // Save Configuration
     const options = {
@@ -1130,15 +1081,15 @@ app.get('/rmhost', (req, res) => {
       },
       body: new_config
     };
-
-    request(options, error => {
-      if (error) {
-        res.end(error);
-      } else {
-        res.end('\nAdded host ' + host + ' to the configuration.');
-      }
-    });
   }
+
+  request(options, error => {
+    if (error) {
+      res.end(error);
+    } else {
+      res.end('\nAdded host ' + host + ' to the configuration.');
+    }
+  });
 });
 
 app.get('/removecontainerconfig', (req, res) => {
@@ -1213,14 +1164,6 @@ app.get('/removecontainerconfig', (req, res) => {
         },
         body: new_config
       };
-
-      request(options, error => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end('\nRemoved Container ' + container + ' from the configuration.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       // Save Configuration
       const options = {
@@ -1233,14 +1176,6 @@ app.get('/removecontainerconfig', (req, res) => {
         },
         body: new_config
       };
-
-      request(options, error => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end('\nRemoved Container ' + container + ' from the configuration.');
-        }
-      });
     } else {
       // Save Configuration
       const options = {
@@ -1252,15 +1187,15 @@ app.get('/removecontainerconfig', (req, res) => {
         },
         body: new_config
       };
-
-      request(options, error => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end('\nRemoved Container ' + container + ' from the configuration.');
-        }
-      });
     }
+
+    request(options, error => {
+      if (error) {
+        res.end(error);
+      } else {
+        res.end('\nRemoved Container ' + container + ' from the configuration.');
+      }
+    });
   }
 });
 
@@ -1329,24 +1264,11 @@ app.get('/addcontainer', (req, res) => {
           body: new_config
         };
 
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            const container_options = {
-              url: `https://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${host}`,
-              rejectUnauthorized: 'false'
-            };
-            // Res.end('\nAdded ' + container + ' to the configuration.');
-            request(container_options, (error, response) => {
-              if (!error && response.statusCode === 200) {
-                res.end('\nAdded ' + container + ' to the configuration.');
-              } else {
-                res.end('\nError connecting with server.');
-              }
-            });
-          }
-        });
+        const container_options = {
+          url: `https://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${host}`,
+          rejectUnauthorized: 'false'
+        };
+
       } else if (config.ssl && config.ssl_self_signed) {
         // Save Configuration
         const options = {
@@ -1359,24 +1281,10 @@ app.get('/addcontainer', (req, res) => {
           body: new_config
         };
 
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            const container_options = {
-              url: `https://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${host}`,
-              rejectUnauthorized: 'false'
-            };
-            // Res.end('\nAdded ' + container + ' to the configuration.');
-            request(container_options, (error, response) => {
-              if (!error && response.statusCode === 200) {
-                res.end('\nAdded ' + container + ' to the configuration.');
-              } else {
-                res.end('\nError connecting with server.');
-              }
-            });
-          }
-        });
+        const container_options = {
+          url: `https://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${host}`,
+          rejectUnauthorized: 'false'
+        };
       } else {
         // Save Configuration
         const options = {
@@ -1389,25 +1297,25 @@ app.get('/addcontainer', (req, res) => {
           body: new_config
         };
 
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            const container_options = {
-              url: `http://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${host}`,
-              rejectUnauthorized: 'false'
-            };
-            // Res.end('\nAdded ' + container + ' to the configuration.');
-            request(container_options, (error, response) => {
-              if (!error && response.statusCode === 200) {
-                res.end('\nAdded ' + container + ' to the configuration.');
-              } else {
-                res.end('\nError connecting with server.');
-              }
-            });
-          }
-        });
+        const container_options = {
+          url: `http://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${host}`,
+          rejectUnauthorized: 'false'
+        };
       }
+
+      request(options, error => {
+        if (error) {
+          res.end(error);
+        } else {
+          request(container_options, (error, response) => {
+            if (!error && response.statusCode === 200) {
+              res.end('\nAdded ' + container + ' to the configuration.');
+            } else {
+              res.end('\nError connecting with server.');
+            }
+          });
+        }
+      });
     }
   }
 });
@@ -1507,15 +1415,6 @@ app.get('/changehost', (req, res) => {
           },
           body: new_config
         };
-
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            migrate(container, original_host, new_host, original_container_data);
-            res.end('\nMigration may take awhile. Please observe the logs and running containers for the latest information.');
-          }
-        });
       } else if (config.ssl && config.ssl_self_signed) {
         // Save Configuration
         const options = {
@@ -1528,15 +1427,6 @@ app.get('/changehost', (req, res) => {
           },
           body: new_config
         };
-
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            migrate(container, original_host, new_host, original_container_data);
-            res.end('\nMigration may take awhile. Please observe the logs and running containers for the latest information.');
-          }
-        });
       } else {
         // Save Configuration
         const options = {
@@ -1548,16 +1438,16 @@ app.get('/changehost', (req, res) => {
           },
           body: new_config
         };
-
-        request(options, error => {
-          if (error) {
-            res.end(error);
-          } else {
-            migrate(container, original_host, new_host, original_container_data);
-            res.end('\nMigration may take awhile. Please observe the logs and running containers for the latest information.');
-          }
-        });
       }
+
+      request(options, error => {
+        if (error) {
+          res.end(error);
+        } else {
+          migrate(container, original_host, new_host, original_container_data);
+          res.end('\nMigration may take awhile. Please observe the logs and running containers for the latest information.');
+        }
+      });
     }
   }
 });
@@ -1596,16 +1486,6 @@ app.get('/stop', (req, res) => {
             },
             body: command
           };
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStopping: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else if (config.ssl && config.ssl_self_signed) {
           const options = {
             url: 'https://' + node + ':' + agent_port + '/run',
@@ -1617,16 +1497,6 @@ app.get('/stop', (req, res) => {
             },
             body: command
           };
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStopping: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else {
           const options = {
             url: 'http://' + node + ':' + agent_port + '/run',
@@ -1637,16 +1507,16 @@ app.get('/stop', (req, res) => {
             },
             body: command
           };
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStopping: ' + key + '\n' + results.output);
-              }
-            });
-          }
+        }
+        if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
+          request(options, (error, response) => {
+            if (error) {
+              res.end('An error has occurred.');
+            } else {
+              const results = JSON.parse(response.body);
+              addLog('\nStopping: ' + key + '\n' + results.output);
+            }
+          });
         }
       });
     });
@@ -1690,17 +1560,6 @@ app.get('/delete', (req, res) => {
             },
             body: command
           };
-
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStopping: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else if (config.ssl && config.ssl_self_signed) {
           const options = {
             url: 'https://' + node + ':' + agent_port + '/run',
@@ -1712,17 +1571,6 @@ app.get('/delete', (req, res) => {
             },
             body: command
           };
-
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStopping: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else {
           const options = {
             url: 'http://' + node + ':' + agent_port + '/run',
@@ -1733,17 +1581,16 @@ app.get('/delete', (req, res) => {
             },
             body: command
           };
-
-          if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nStopping: ' + key + '\n' + results.output);
-              }
-            });
-          }
+        }
+        if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
+          request(options, (error, response) => {
+            if (error) {
+              res.end('An error has occurred.');
+            } else {
+              const results = JSON.parse(response.body);
+              addLog('\nStopping: ' + key + '\n' + results.output);
+            }
+          });
         }
       });
     });
@@ -1785,16 +1632,6 @@ app.get('/restart', (req, res) => {
             },
             body: command
           };
-          if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nRestarting: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else if (config.ssl && config.ssl_self_signed) {
           const options = {
             url: 'https://' + node + ':' + agent_port + '/run',
@@ -1806,16 +1643,6 @@ app.get('/restart', (req, res) => {
             },
             body: command
           };
-          if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nRestarting: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else {
           const options = {
             url: 'http://' + node + ':' + agent_port + '/run',
@@ -1826,16 +1653,17 @@ app.get('/restart', (req, res) => {
             },
             body: command
           };
-          if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nRestarting: ' + key + '\n' + results.output);
-              }
-            });
-          }
+        }
+
+        if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
+          request(options, (error, response) => {
+            if (error) {
+              res.end('An error has occurred.');
+            } else {
+              const results = JSON.parse(response.body);
+              addLog('\nRestarting: ' + key + '\n' + results.output);
+            }
+          });
         }
       });
     });
@@ -1878,16 +1706,6 @@ app.get('/containerlog', (req, res) => {
             },
             body: command
           };
-          if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nLogs for Container: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else if (config.ssl && config.ssl_self_signed) {
           const options = {
             url: 'https://' + node + ':' + agent_port + '/run',
@@ -1899,16 +1717,6 @@ app.get('/containerlog', (req, res) => {
             },
             body: command
           };
-          if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nLogs for Container: ' + key + '\n' + results.output);
-              }
-            });
-          }
         } else {
           const options = {
             url: 'http://' + node + ':' + agent_port + '/run',
@@ -1919,16 +1727,16 @@ app.get('/containerlog', (req, res) => {
             },
             body: command
           };
-          if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
-            request(options, (error, response) => {
-              if (error) {
-                res.end('An error has occurred.');
-              } else {
-                const results = JSON.parse(response.body);
-                addLog('\nLogs for Container: ' + key + '\n' + results.output);
-              }
-            });
-          }
+        }
+        if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
+          request(options, (error, response) => {
+            if (error) {
+              res.end('An error has occurred.');
+            } else {
+              const results = JSON.parse(response.body);
+              addLog('\nLogs for Container: ' + key + '\n' + results.output);
+            }
+          });
         }
       });
     });
@@ -1997,37 +1805,29 @@ function copyToAgents(file) {
       };
 
       if (config.ssl) {
-        request.post({
+        const form_options = {
           url: 'https://' + node + ':' + agent_port + '/receive-file',
           formData
-        }, err => {
-          if (!err) {
-            addLog('\nCopied ' + file + ' to ' + node);
-            console.log('\nCopied ' + file + ' to ' + node);
-          }
-        });
+        };
       } else if (config.ssl && config.ssl_self_signed) {
-        request.post({
+        const form_options = {
           url: 'https://' + node + ':' + agent_port + '/receive-file',
           rejectUnauthorized: 'false',
           formData
-        }, err => {
-          if (!err) {
-            addLog('\nCopied ' + file + ' to ' + node);
-            console.log('\nCopied ' + file + ' to ' + node);
-          }
-        });
+        };
       } else {
-        request.post({
+        const form_options = {
           url: 'http://' + node + ':' + agent_port + '/receive-file',
           formData
-        }, err => {
-          if (!err) {
-            addLog('\nCopied ' + file + ' to ' + node);
-            console.log('\nCopied ' + file + ' to ' + node);
-          }
-        });
+        };
       }
+
+      request.post(form_options, err => {
+        if (!err) {
+          addLog('\nCopied ' + file + ' to ' + node);
+          console.log('\nCopied ' + file + ' to ' + node);
+        }
+      });
     });
   });
 }
@@ -2079,14 +1879,15 @@ app.post('/exec', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const command = JSON.stringify({
-        command: req.body.command,
-        token
-      });
+    const command = JSON.stringify({
+      command: req.body.command,
+      token
+    });
 
-      for (let i = 0; i < config.layout.length; i++) {
-        const node = config.layout[i].node;
+    for (let i = 0; i < config.layout.length; i++) {
+      const node = config.layout[i].node;
+
+      if (config.ssl) {
         const options = {
           url: 'https://' + node + ':' + agent_port + '/run',
           method: 'POST',
@@ -2096,37 +1897,7 @@ app.post('/exec', (req, res) => {
           },
           body: command
         };
-
-        if (selected_node.length === 0) {
-          request(options, (error, response) => {
-            if (error) {
-              res.end('An error has occurred.');
-            } else {
-              const results = JSON.parse(response.body);
-              addLog('\nNode:' + results.node + '\n' + results.output);
-            }
-          });
-        }
-        if (selected_node.indexOf(node) > -1) {
-          request(options, (error, response) => {
-            if (error) {
-              res.end('An error has occurred.');
-            } else {
-              const results = JSON.parse(response.body);
-              addLog('\nNode:' + results.node + '\n' + results.output);
-            }
-          });
-        }
-        res.end('');
-      }
-    } else if (config.ssl && config.ssl_self_signed) {
-      const command = JSON.stringify({
-        command: req.body.command,
-        token
-      });
-
-      for (let i = 0; i < config.layout.length; i++) {
-        const node = config.layout[i].node;
+      } else if (config.ssl && config.ssl_self_signed) {
         const options = {
           url: 'https://' + node + ':' + agent_port + '/run',
           rejectUnauthorized: 'false',
@@ -2137,37 +1908,7 @@ app.post('/exec', (req, res) => {
           },
           body: command
         };
-
-        if (selected_node.length === 0) {
-          request(options, (error, response) => {
-            if (error) {
-              res.end('An error has occurred.');
-            } else {
-              const results = JSON.parse(response.body);
-              addLog('\nNode:' + results.node + '\n' + results.output);
-            }
-          });
-        }
-        if (selected_node.indexOf(node) > -1) {
-          request(options, (error, response) => {
-            if (error) {
-              res.end('An error has occurred.');
-            } else {
-              const results = JSON.parse(response.body);
-              addLog('\nNode:' + results.node + '\n' + results.output);
-            }
-          });
-        }
-        res.end('');
-      }
-    } else {
-      const command = JSON.stringify({
-        command: req.body.command,
-        token
-      });
-
-      for (let i = 0; i < config.layout.length; i++) {
-        const node = config.layout[i].node;
+      } else {
         const options = {
           url: 'http://' + node + ':' + agent_port + '/run',
           method: 'POST',
@@ -2177,29 +1918,29 @@ app.post('/exec', (req, res) => {
           },
           body: command
         };
-
-        if (selected_node.length === 0) {
-          request(options, (error, response) => {
-            if (error) {
-              res.end('An error has occurred.');
-            } else {
-              const results = JSON.parse(response.body);
-              addLog('\nNode:' + results.node + '\n' + results.output);
-            }
-          });
-        }
-        if (selected_node.indexOf(node) > -1) {
-          request(options, (error, response) => {
-            if (error) {
-              res.end('An error has occurred.');
-            } else {
-              const results = JSON.parse(response.body);
-              addLog('\nNode:' + results.node + '\n' + results.output);
-            }
-          });
-        }
-        res.end('');
       }
+
+      if (selected_node.length === 0) {
+        request(options, (error, response) => {
+          if (error) {
+            res.end('An error has occurred.');
+          } else {
+            const results = JSON.parse(response.body);
+            addLog('\nNode:' + results.node + '\n' + results.output);
+          }
+        });
+      }
+      if (selected_node.indexOf(node) > -1) {
+        request(options, (error, response) => {
+          if (error) {
+            res.end('An error has occurred.');
+          } else {
+            const results = JSON.parse(response.body);
+            addLog('\nNode:' + results.node + '\n' + results.output);
+          }
+        });
+      }
+      res.end('');
     }
   }
 });
@@ -2226,16 +1967,6 @@ app.get('/prune', (req, res) => {
           },
           body: command
         };
-
-        request(options, (error, response) => {
-          if (error) {
-            res.end('An error has occurred.');
-          } else {
-            const results = JSON.parse(response.body);
-            addLog('\nNode:' + results.node + '\n' + results.output);
-            console.log('\nNode:' + results.node + '\n' + results.output);
-          }
-        });
       } else if (config.ssl && config.ssl_self_signed) {
         const options = {
           url: 'https://' + node + ':' + agent_port + '/run',
@@ -2247,16 +1978,6 @@ app.get('/prune', (req, res) => {
           },
           body: command
         };
-
-        request(options, (error, response) => {
-          if (error) {
-            res.end('An error has occurred.');
-          } else {
-            const results = JSON.parse(response.body);
-            addLog('\nNode:' + results.node + '\n' + results.output);
-            console.log('\nNode:' + results.node + '\n' + results.output);
-          }
-        });
       } else {
         const options = {
           url: 'http://' + node + ':' + agent_port + '/run',
@@ -2267,17 +1988,18 @@ app.get('/prune', (req, res) => {
           },
           body: command
         };
-
-        request(options, (error, response) => {
-          if (error) {
-            res.end('An error has occurred.');
-          } else {
-            const results = JSON.parse(response.body);
-            addLog('\nNode:' + results.node + '\n' + results.output);
-            console.log('\nNode:' + results.node + '\n' + results.output);
-          }
-        });
       }
+
+      request(options, (error, response) => {
+        if (error) {
+          res.end('An error has occurred.');
+        } else {
+          const results = JSON.parse(response.body);
+          addLog('\nNode:' + results.node + '\n' + results.output);
+          console.log('\nNode:' + results.node + '\n' + results.output);
+        }
+      });
+
       res.end('');
     }
   }
@@ -2292,42 +2014,26 @@ function move_container(container, newhost) {
       url: `https://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`,
       method: 'GET'
     };
-
-    request(options, error => {
-      if (error) {
-        console.log('Error connecting with server. ' + error);
-      } else {
-        config.automatic_heartbeat = 'enabled';
-      }
-    });
   } else if (config.ssl && config.ssl_self_signed) {
     const options = {
       url: `https://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`,
       rejectUnauthorized: 'false',
       method: 'GET'
     };
-
-    request(options, error => {
-      if (error) {
-        console.log('Error connecting with server. ' + error);
-      } else {
-        config.automatic_heartbeat = 'enabled';
-      }
-    });
   } else {
     const options = {
       url: `http://127.0.0.1:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`,
       method: 'GET'
     };
-
-    request(options, error => {
-      if (error) {
-        console.log('Error connecting with server. ' + error);
-      } else {
-        config.automatic_heartbeat = 'enabled';
-      }
-    });
   }
+
+  request(options, error => {
+    if (error) {
+      console.log('Error connecting with server. ' + error);
+    } else {
+      config.automatic_heartbeat = 'enabled';
+    }
+  });
 }
 
 function container_failover(container) {
@@ -2468,40 +2174,24 @@ app.get('/rsyslog', (req, res) => {
       const options = {
         url: 'https://' + config.rsyslog_host + ':' + config.agent_port + '/rsyslog?token=' + token
       };
-
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('Error connecting with server. ' + error);
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + config.rsyslog_host + ':' + config.agent_port + '/rsyslog?token=' + token,
         rejectUnauthorized: 'false'
       };
-
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('Error connecting with server. ' + error);
-        }
-      });
     } else {
       const options = {
         url: 'http://' + config.rsyslog_host + ':' + config.agent_port + '/rsyslog?token=' + token
       };
-
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('Error connecting with server. ' + error);
-        }
-      });
     }
+
+    request(options, (error, response, body) => {
+      if (!error && response.statusCode === 200) {
+        res.end(body);
+      } else {
+        res.end('Error connecting with server. ' + error);
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -2567,12 +2257,6 @@ app.get('/killvip', (req, res) => {
               },
               body: token_body
             };
-
-            request(options, error => {
-              if (error) {
-                res.end('An error has occurred.');
-              }
-            });
           } else if (config.ssl && config.ssl_self_signed) {
             const options = {
               url: 'https://' + node + ':' + agent_port + '/killvip',
@@ -2584,12 +2268,6 @@ app.get('/killvip', (req, res) => {
               },
               body: token_body
             };
-
-            request(options, error => {
-              if (error) {
-                res.end('An error has occurred.');
-              }
-            });
           } else {
             const options = {
               url: 'http://' + node + ':' + agent_port + '/killvip',
@@ -2600,13 +2278,13 @@ app.get('/killvip', (req, res) => {
               },
               body: token_body
             };
-
-            request(options, error => {
-              if (error) {
-                res.end('An error has occurred.');
-              }
-            });
           }
+
+          request(options, error => {
+            if (error) {
+              res.end('An error has occurred.');
+            }
+          });
         });
       });
     }

--- a/server/server.js
+++ b/server/server.js
@@ -31,7 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed ? false : true;
+const ssl_self_signed = config.ssl_self_signed !== false;
 const server = config.web_connect;
 const rsyslog_host = config.rsyslog_host;
 const server_port = config.server_port;

--- a/server/server.js
+++ b/server/server.js
@@ -452,151 +452,18 @@ app.get('/start', (req, res) => {
 
 function migrate(container, original_host, new_host, original_container_data) {
   let existing_automatic_heartbeat_value = '';
+
   if (config.automatic_heartbeat) {
     existing_automatic_heartbeat_value = config.automatic_heartbeat;
     if (config.automatic_heartbeat.indexOf('enabled') > -1) {
       config.automatic_heartbeat = 'disabled';
     }
   }
+
   const command = JSON.stringify({
     command: 'docker rm -f ' + container,
     token
   });
-  if (config.ssl) {
-    const options = {
-      url: 'https://' + original_host + ':' + agent_port + '/run',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': command.length
-      },
-      body: command
-    };
-
-    request(options, error => {
-      if (error) {
-        addLog('An error has occurred.');
-      } else {
-        const command = JSON.stringify({
-          command: `docker image build ${dockerFolder}/${container} -t ${container} -f ${dockerFolder}/${container}/Dockerfile;docker container run -d --name ${container} ${original_container_data} ${container}`,
-          token
-        });
-
-        const options = {
-          url: 'https://' + new_host + ':' + agent_port + '/run',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Length': command.length
-          },
-          body: command
-        };
-
-        request(options, error => {
-          if (error) {
-            addLog('An error has occurred.');
-          } else {
-            const command = JSON.stringify({
-              command: 'docker container run -d --name ' + container + ' ' + original_container_data + ' ' + container,
-              token
-            });
-
-            const options = {
-              url: 'https://' + new_host + ':' + agent_port + '/run',
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'Content-Length': command.length
-              },
-              body: command
-            };
-
-            request(options, error => {
-              if (error) {
-                addLog('An error has occurred.');
-              } else {
-                addLog('\nStarting ' + container);
-                if (config.automatic_heartbeat) {
-                  if (existing_automatic_heartbeat_value.indexOf('enabled') > -1) {
-                    config.automatic_heartbeat = existing_automatic_heartbeat_value;
-                  }
-                }
-              }
-            });
-          }
-        });
-      }
-    });
-  } else if (config.ssl && config.ssl_self_signed) {
-    const options = {
-      url: 'https://' + original_host + ':' + agent_port + '/run',
-      method: 'POST',
-      rejectUnauthorized: 'false',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': command.length
-      },
-      body: command
-    };
-
-    request(options, error => {
-      if (error) {
-        addLog('An error has occurred.');
-      } else {
-        const command = JSON.stringify({
-          command: `docker image build ${dockerFolder}/${container} -t ${container} -f ${dockerFolder}/${container}/Dockerfile;docker container run -d --name ${container} ${original_container_data} ${container}`,
-          token
-        });
-
-        const options = {
-          url: 'https://' + new_host + ':' + agent_port + '/run',
-          rejectUnauthorized: 'false',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Length': command.length
-          },
-          body: command
-        };
-
-        request(options, error => {
-          if (error) {
-            addLog('An error has occurred.');
-          } else {
-            const command = JSON.stringify({
-              command: 'docker container run -d --name ' + container + ' ' + original_container_data + ' ' + container,
-              token
-            });
-
-            const options = {
-              url: 'https://' + new_host + ':' + agent_port + '/run',
-              rejectUnauthorized: 'false',
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'Content-Length': command.length
-              },
-              body: command
-            };
-
-            request(options, error => {
-              if (error) {
-                addLog('An error has occurred.');
-              } else {
-                addLog('\nStarting ' + container);
-                if (config.automatic_heartbeat) {
-                  if (existing_automatic_heartbeat_value.indexOf('enabled') > -1) {
-                    config.automatic_heartbeat = existing_automatic_heartbeat_value;
-                  }
-                }
-              }
-            });
-          }
-        });
-      }
-    });
-  } else {
-  }
 
   const options = {
     url: `${scheme}${original_host}:${agent_port}/run`,
@@ -1776,7 +1643,7 @@ app.get('/killvip', (req, res) => {
           if ((!config.vip[i].hasOwnProperty(key) || key.indexOf('node') > -1)) {
             return;
           }
-          
+
           const token_body = JSON.stringify({
             token
           });

--- a/server/server.js
+++ b/server/server.js
@@ -121,6 +121,7 @@ function automatic_heartbeat() {
 
 app.get('/clearlog', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -159,6 +160,7 @@ app.get('/nodes', (req, res) => {
         }
       }
     }
+
     node_metrics.total_containers = total_containers;
     node_metrics.total_nodes = total_node_count;
     node_metrics.container_list = container_list;
@@ -212,6 +214,7 @@ app.get('/build', (req, res) => {
   const check_token = req.query.token;
   const no_cache = req.query.no_cache;
   let image = '';
+
   if (req.query.image) {
     image = req.query.image;
   }
@@ -226,10 +229,12 @@ app.get('/build', (req, res) => {
     Object.keys(config.layout).forEach((get_node, i) => {
       Object.keys(config.layout[i]).forEach(key => {
         const node = config.layout[i].node;
+        let command;
+
         if ((!config.layout[i].hasOwnProperty(key) || key.indexOf('node') > -1)) {
           return;
         }
-        let command;
+
         if (no_cache.indexOf('true') > -1) {
           command = JSON.stringify({
             command: 'docker image build --no-cache ' + dockerFolder + '/' + key + ' -t ' + key + ' -f ' + dockerFolder + '/' + key + '/Dockerfile',
@@ -275,6 +280,7 @@ app.get('/build', (req, res) => {
 app.get('/delete-image', (req, res) => {
   const check_token = req.query.token;
   let image = '';
+
   if (req.query.image) {
     image = req.query.image;
   }
@@ -397,9 +403,11 @@ app.get('/create', (req, res) => {
 app.get('/start', (req, res) => {
   const check_token = req.query.token;
   let container = '';
+
   if (req.query.container) {
     container = req.query.container;
   }
+
   if (container.indexOf('*') > -1) {
     container = '*';
   }
@@ -558,7 +566,6 @@ app.get('/addhost', (req, res) => {
     }
 
     if (proceed) {
-      // Add New Host
       config.layout.push({
         node: host
       });
@@ -688,6 +695,7 @@ app.get('/rmhost', (req, res) => {
       }
     }
   }
+
   const new_config = JSON.stringify({
     payload: JSON.stringify(config),
     token
@@ -814,6 +822,7 @@ app.get('/addcontainer', (req, res) => {
   } else {
     // Ensures that the host exists
     let proceed = 0;
+
     for (let i = 0; i < config.layout.length; i++) {
       if (config.layout[i].node.indexOf(host) > -1) {
         proceed++;
@@ -824,7 +833,6 @@ app.get('/addcontainer', (req, res) => {
       res.end('\nError: Node does not exist!');
     } else {
       // Add Data to New Host
-
       for (let i = 0; i < config.layout.length; i++) {
         if (config.layout[i].node.indexOf(host) > -1) {
           config.layout[i][container] = container_args;
@@ -924,10 +932,10 @@ app.get('/changehost', (req, res) => {
       }
     }
 
+  // Find Current Host
     if (proceed < 2) {
       res.end('\nError: Node or Container does not exist!');
     } else {
-      // Find Current Host
       for (let i = 0; i < config.layout.length; i++) {
         for (const key in config.layout[i]) {
           if (container.length > 0) {
@@ -940,8 +948,8 @@ app.get('/changehost', (req, res) => {
         }
       }
 
+      // Checks for HB
       if (config.hb) {
-        // Checks for HB
         for (let i = 0; i < config.hb.length; i++) {
           for (const key in config.hb[i]) {
             if (container.length > 0) {
@@ -1005,9 +1013,11 @@ app.get('/changehost', (req, res) => {
 app.get('/stop', (req, res) => {
   const check_token = req.query.token;
   let container = '';
+
   if (req.query.container) {
     container = req.query.container;
   }
+
   if (container.indexOf('*') > -1) {
     container = '*';
   }
@@ -1061,6 +1071,7 @@ app.get('/stop', (req, res) => {
 app.get('/delete', (req, res) => {
   const check_token = req.query.token;
   let container = '';
+
   if (req.query.container) {
     container = req.query.container;
   }
@@ -1118,9 +1129,11 @@ app.get('/delete', (req, res) => {
 app.get('/restart', (req, res) => {
   const check_token = req.query.token;
   let selected_container = '';
+
   if (req.query.container) {
     selected_container = req.query.container;
   }
+
   if (selected_container.indexOf('*') > -1) {
     selected_container = '*';
   }
@@ -1174,9 +1187,11 @@ app.get('/restart', (req, res) => {
 app.get('/containerlog', (req, res) => {
   const check_token = req.query.token;
   let selected_container = '';
+
   if (req.query.container) {
     selected_container = req.query.container;
   }
+
   if (selected_container.indexOf('*') > -1) {
     selected_container = '*';
   }
@@ -1232,6 +1247,7 @@ app.post('/listcontainers', (req, res) => {
   const check_token = req.body.token;
   const output = [];
   let container;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1255,6 +1271,7 @@ app.post('/listnodes', (req, res) => {
   const check_token = req.body.token;
   const output = [];
   let node;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1309,6 +1326,7 @@ function copyToAgents(file) {
 
 app.post('/receive-file', upload.single('file'), (req, res) => {
   const check_token = req.body.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1330,6 +1348,7 @@ app.post('/receive-file', upload.single('file'), (req, res) => {
 
 app.post('/listcommands', (req, res) => {
   const check_token = req.body.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else if (config.commandlist) {
@@ -1339,10 +1358,10 @@ app.post('/listcommands', (req, res) => {
   }
 });
 
-/* eslint-disable no-lonely-if */
 app.post('/exec', (req, res) => {
   const check_token = req.body.token;
   let selected_node = '';
+
   if (req.body.node) {
     selected_node = req.body.node;
   }
@@ -1386,6 +1405,7 @@ app.post('/exec', (req, res) => {
           }
         });
       }
+
       if (selected_node.indexOf(node) > -1) {
         request(options, (error, response) => {
           if (error) {
@@ -1400,10 +1420,10 @@ app.post('/exec', (req, res) => {
     }
   }
 });
-/* eslint-enable no-lonely-if */
 
 app.get('/prune', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1411,6 +1431,7 @@ app.get('/prune', (req, res) => {
       command: 'docker system prune -a -f',
       token
     });
+
     for (let i = 0; i < config.layout.length; i++) {
       const node = config.layout[i].node;
 
@@ -1535,18 +1556,21 @@ function hb_check(node, container_port, container) {
 
 app.get('/hb', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
     let node = '';
     let check_port = '';
     let container = '';
+
     for (let i = 0; i < config.hb.length; i++) {
       for (const key in config.hb[i]) {
         if (config.hb[i].hasOwnProperty(key)) {
           container = key;
           node = config.hb[i].node;
           check_port = config.hb[i][key];
+
           if (check_port !== node) {
             hb_check(node, check_port, container);
           }
@@ -1559,6 +1583,7 @@ app.get('/hb', (req, res) => {
 
 app.get('/log', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1569,7 +1594,6 @@ app.get('/log', (req, res) => {
   }
 });
 
-/* eslint-disable no-lonely-if */
 app.get('/rsyslog', (req, res) => {
   const check_token = req.query.token;
 
@@ -1593,10 +1617,10 @@ app.get('/rsyslog', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
 app.get('/reloadconfig', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1614,6 +1638,7 @@ app.get('/reloadconfig', (req, res) => {
         automatic_heartbeat();
       }
     }
+
     addLog('\nReloading Config.json\n');
     res.end('');
   }
@@ -1621,6 +1646,7 @@ app.get('/reloadconfig', (req, res) => {
 
 app.get('/getconfig', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1630,6 +1656,7 @@ app.get('/getconfig', (req, res) => {
 
 app.get('/killvip', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1680,10 +1707,12 @@ app.post('/updateconfig', (req, res) => {
 
   try {
     const verify_payload = JSON.parse(req.body.payload);
+
     if ((check_token !== token) || (!check_token)) {
       res.end('\nError: Invalid Credentials');
     } else {
       payload = JSON.stringify(verify_payload, null, 4);
+
       fs.writeFile(config_file, payload, err => {
         if (err) {
           console.log('\nError while writing config.' + err);

--- a/server/server.js
+++ b/server/server.js
@@ -106,7 +106,7 @@ function automatic_heartbeat() {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
       }
 
       request.get(options).on('error', e => {
@@ -186,7 +186,7 @@ app.get('/nodes', (req, res) => {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
       }
 
       request(options, (error, response) => {
@@ -258,7 +258,7 @@ app.get('/build', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((image.indexOf('*') > -1) || key.indexOf(image) > -1) {
@@ -316,7 +316,7 @@ app.get('/delete-image', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((image.indexOf('*') > -1) || key.indexOf(image) > -1) {
@@ -374,7 +374,7 @@ app.get('/create', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((key.indexOf(container) > -1) || (container.indexOf('*')) > -1) {
@@ -439,7 +439,7 @@ app.get('/start', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
@@ -484,7 +484,7 @@ function migrate(container, original_host, new_host, original_container_data) {
   };
 
   if (config.ssl_self_signed) {
-    options.rejectUnauthorized = 'false';
+    options['rejectUnauthorized'] = 'false';
   }
 
   request(options, error => {
@@ -507,7 +507,7 @@ function migrate(container, original_host, new_host, original_container_data) {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
       }
 
       request(options, error => {
@@ -530,7 +530,7 @@ function migrate(container, original_host, new_host, original_container_data) {
           };
 
           if (config.ssl_self_signed) {
-            options.rejectUnauthorized = 'false';
+            options['rejectUnauthorized'] = 'false';
           }
 
           request(options, error => {
@@ -592,7 +592,7 @@ app.get('/addhost', (req, res) => {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
       }
 
       request(options, error => {
@@ -712,7 +712,7 @@ app.get('/rmhost', (req, res) => {
   };
 
   if (config.ssl_self_signed) {
-    options.rejectUnauthorized = 'false';
+    options['rejectUnauthorized'] = 'false';
   }
 
   request(options, error => {
@@ -796,7 +796,7 @@ app.get('/removecontainerconfig', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, error => {
@@ -879,8 +879,8 @@ app.get('/addcontainer', (req, res) => {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
-        container_options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
+        container_options['rejectUnauthorized'] = 'false';
       }
 
       request(options, error => {
@@ -995,7 +995,7 @@ app.get('/changehost', (req, res) => {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
       }
 
       request(options, error => {
@@ -1049,7 +1049,7 @@ app.get('/stop', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
@@ -1107,7 +1107,7 @@ app.get('/delete', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((container.indexOf('*') > -1) || key.indexOf(container) > -1) {
@@ -1165,7 +1165,7 @@ app.get('/restart', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
@@ -1223,7 +1223,7 @@ app.get('/containerlog', (req, res) => {
         };
 
         if (config.ssl_self_signed) {
-          options.rejectUnauthorized = 'false';
+          options['rejectUnauthorized'] = 'false';
         }
 
         if ((selected_container.indexOf('*') > -1) || key.indexOf(selected_container) > -1) {
@@ -1311,7 +1311,7 @@ function copyToAgents(file) {
       };
 
       if (config.ssl_self_signed) {
-        form_options.rejectUnauthorized = 'false';
+        form_options['rejectUnauthorized'] = 'false';
       }
 
       request.post(form_options, err => {
@@ -1392,7 +1392,7 @@ app.post('/exec', (req, res) => {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
       }
 
       if (selected_node.length === 0) {
@@ -1446,7 +1446,7 @@ app.get('/prune', (req, res) => {
       };
 
       if (config.ssl_self_signed) {
-        options.rejectUnauthorized = 'false';
+        options['rejectUnauthorized'] = 'false';
       }
 
       request(options, (error, response) => {
@@ -1474,7 +1474,7 @@ function move_container(container, newhost) {
   };
 
   if (config.ssl_self_signed) {
-    options.rejectUnauthorized = 'false';
+    options['rejectUnauthorized'] = 'false';
   }
 
   request(options, error => {
@@ -1605,7 +1605,7 @@ app.get('/rsyslog', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -1686,7 +1686,7 @@ app.get('/killvip', (req, res) => {
           };
 
           if (config.ssl_self_signed) {
-            options.rejectUnauthorized = 'false';
+            options['rejectUnauthorized'] = 'false';
           }
 
           request(options, error => {

--- a/server/server.js
+++ b/server/server.js
@@ -31,7 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed !== false;
+const ssl_self_signed = config.ssl_self_signed === false;
 const server = config.web_connect;
 const rsyslog_host = config.rsyslog_host;
 const server_port = config.server_port;

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -31,7 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed ? 'false' : 'true';
+const ssl_self_signed = config.ssl_self_signed ? false : true;
 const request_timeout = 5000;
 const web_port = config.web_port;
 let token = config.token;

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -50,64 +50,34 @@ function getData() {
       const options = {
         url: 'https://' + server + ':' + server_port + '/nodes?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          /* eslint-disable no-unused-vars */
-          let json;
-          let statusCode = 200;
-          try {
-            nodedata = JSON.parse(response.body);
-          } catch (err) {
-            statusCode = 500;
-            console.error(err);
-          }
-          /* eslint-enable no-unused-vars */
-        } else {
-          console.log('\nError connecting with server. ' + error);
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/nodes?token=' + token,
         rejectUnauthorized: false
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          /* eslint-disable no-unused-vars */
-          let json;
-          let statusCode = 200;
-          try {
-            nodedata = JSON.parse(response.body);
-          } catch (err) {
-            statusCode = 500;
-            console.error(err);
-          }
-          /* eslint-enable no-unused-vars */
-        } else {
-          console.log('\nError connecting with server. ' + error);
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/nodes?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          /* eslint-disable no-unused-vars */
-          let json;
-          let statusCode = 200;
-          try {
-            nodedata = JSON.parse(response.body);
-          } catch (err) {
-            statusCode = 500;
-            console.error(err);
-          }
-          /* eslint-enable no-unused-vars */
-        } else {
-          console.log('\nError connecting with server. ' + error);
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        /* eslint-disable no-unused-vars */
+        let json;
+        let statusCode = 200;
+        try {
+          nodedata = JSON.parse(response.body);
+        } catch (err) {
+          statusCode = 500;
+          console.error(err);
+        }
+        /* eslint-enable no-unused-vars */
+      } else {
+        console.log('\nError connecting with server. ' + error);
+      }
+    });
+
     getData();
   }, 5000);
 }
@@ -162,14 +132,6 @@ app.post('/sendconfig', (req, res) => {
         body: command,
         token
       };
-
-      request(options, (error, response, body) => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end(body);
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/updateconfig',
@@ -182,14 +144,6 @@ app.post('/sendconfig', (req, res) => {
         body: command,
         token
       };
-
-      request(options, (error, response, body) => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end(body);
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/updateconfig',
@@ -201,15 +155,15 @@ app.post('/sendconfig', (req, res) => {
         body: command,
         token
       };
-
-      request(options, (error, response, body) => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end(body);
-        }
-      });
     }
+
+    request(options, (error, response, body) => {
+      if (error) {
+        res.end(error);
+      } else {
+        res.end(body);
+      }
+    });
   }
 });
 
@@ -229,19 +183,18 @@ app.post('/', (req, res) => {
 });
 
 app.post('/exec', (req, res) => {
-  if (config.ssl) {
-    const check_token = req.body.token;
-    const node = req.body.node;
+  const check_token = req.body.token;
+  const node = req.body.node;
 
-    if ((check_token !== token) || (!check_token)) {
-      res.end('\nError: Invalid Credentials');
-    } else {
-      const command = JSON.stringify({
-        command: req.body.command,
-        token,
-        node
-      });
-
+  if ((check_token !== token) || (!check_token)) {
+    res.end('\nError: Invalid Credentials');
+  } else {
+    const command = JSON.stringify({
+      command: req.body.command,
+      token,
+      node
+    });
+    if (config.ssl) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/exec',
         method: 'POST',
@@ -251,30 +204,7 @@ app.post('/exec', (req, res) => {
         },
         body: command
       };
-
-      request(options, error => {
-        if (error) {
-          res.end(error);
-        } else {
-          display_log(data => {
-            res.end(data);
-          });
-        }
-      });
-    }
-  } else if (config.ssl && config.ssl_self_signed) {
-    const check_token = req.body.token;
-    const node = req.body.node;
-
-    if ((check_token !== token) || (!check_token)) {
-      res.end('\nError: Invalid Credentials');
-    } else {
-      const command = JSON.stringify({
-        command: req.body.command,
-        token,
-        node
-      });
-
+    } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/exec',
         rejectUnauthorized: 'false',
@@ -285,30 +215,7 @@ app.post('/exec', (req, res) => {
         },
         body: command
       };
-
-      request(options, error => {
-        if (error) {
-          res.end(error);
-        } else {
-          display_log(data => {
-            res.end(data);
-          });
-        }
-      });
-    }
-  } else {
-    const check_token = req.body.token;
-    const node = req.body.node;
-
-    if ((check_token !== token) || (!check_token)) {
-      res.end('\nError: Invalid Credentials');
     } else {
-      const command = JSON.stringify({
-        command: req.body.command,
-        token,
-        node
-      });
-
       const options = {
         url: 'http://' + server + ':' + server_port + '/exec',
         method: 'POST',
@@ -318,17 +225,17 @@ app.post('/exec', (req, res) => {
         },
         body: command
       };
-
-      request(options, error => {
-        if (error) {
-          res.end(error);
-        } else {
-          display_log(data => {
-            res.end(data);
-          });
-        }
-      });
     }
+
+    request(options, error => {
+      if (error) {
+        res.end(error);
+      } else {
+        display_log(data => {
+          res.end(data);
+        });
+      }
+    });
   }
 });
 
@@ -460,14 +367,6 @@ app.post('/listcommands', (req, res) => {
         },
         body: token_body
       };
-
-      request(options, (error, response, body) => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end(body);
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/listcommands',
@@ -479,14 +378,6 @@ app.post('/listcommands', (req, res) => {
         },
         body: token_body
       };
-
-      request(options, (error, response, body) => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end(body);
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/listcommands',
@@ -497,66 +388,45 @@ app.post('/listcommands', (req, res) => {
         },
         body: token_body
       };
-
-      request(options, (error, response, body) => {
-        if (error) {
-          res.end(error);
-        } else {
-          res.end(body);
-        }
-      });
     }
+
+    request(options, (error, response, body) => {
+      if (error) {
+        res.end(error);
+      } else {
+        res.end(body);
+      }
+    });
   }
 });
 
 function display_log(callback) {
   if (config.ssl) {
-    clear_log(() => {
-      setTimeout(() => {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/log?token=' + token
-        };
-        request(options, (error, response, body) => {
-          if (!error && response.statusCode === 200) {
-            callback(body);
-          } else {
-            callback('\nError connecting with server.');
-          }
-        });
-      }, request_timeout);
-    });
+    const options = {
+      url: 'https://' + server + ':' + server_port + '/log?token=' + token
+    };
   } else if (config.ssl && config.ssl_self_signed) {
-    clear_log(() => {
-      setTimeout(() => {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/log?token=' + token,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response, body) => {
-          if (!error && response.statusCode === 200) {
-            callback(body);
-          } else {
-            callback('\nError connecting with server.');
-          }
-        });
-      }, request_timeout);
-    });
+    const options = {
+      url: 'https://' + server + ':' + server_port + '/log?token=' + token,
+      rejectUnauthorized: 'false'
+    };
   } else {
-    clear_log(() => {
-      setTimeout(() => {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/log?token=' + token
-        };
-        request(options, (error, response, body) => {
-          if (!error && response.statusCode === 200) {
-            callback(body);
-          } else {
-            callback('\nError connecting with server.');
-          }
-        });
-      }, request_timeout);
-    });
+    const options = {
+      url: 'http://' + server + ':' + server_port + '/log?token=' + token
+    };
   }
+
+  clear_log(() => {
+    setTimeout(() => {
+      request(options, (error, response, body) => {
+        if (!error && response.statusCode === 200) {
+          callback(body);
+        } else {
+          callback('\nError connecting with server.');
+        }
+      });
+    }, request_timeout);
+  });
 }
 
 function clear_log(callback) {
@@ -564,37 +434,24 @@ function clear_log(callback) {
     const options = {
       url: 'https://' + server + ':' + server_port + '/clearlog?token=' + token
     };
-    request(options, (error, response) => {
-      if (!error && response.statusCode === 200) {
-        callback('');
-      } else {
-        console.log('\nError clearing log: ' + error);
-      }
-    });
   } else if (config.ssl && config.ssl_self_signed) {
     const options = {
       url: 'https://' + server + ':' + server_port + '/clearlog?token=' + token,
       rejectUnauthorized: 'false'
     };
-    request(options, (error, response) => {
-      if (!error && response.statusCode === 200) {
-        callback('');
-      } else {
-        console.log('\nError clearing log: ' + error);
-      }
-    });
   } else {
     const options = {
       url: 'http://' + server + ':' + server_port + '/clearlog?token=' + token
     };
-    request(options, (error, response) => {
-      if (!error && response.statusCode === 200) {
-        callback('');
-      } else {
-        console.log('\nError clearing log: ' + error);
-      }
-    });
   }
+
+  request(options, (error, response) => {
+    if (!error && response.statusCode === 200) {
+      callback('');
+    } else {
+      console.log('\nError clearing log: ' + error);
+    }
+  });
 }
 
 /* eslint-disable no-lonely-if */
@@ -611,43 +468,26 @@ app.post('/containerlog', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/containerlog?token=' + token + '&container=' + container
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end('\n' + data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/containerlog?token=' + token + '&container=' + container,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end('\n' + data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/containerlog?token=' + token + '&container=' + container
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end('\n' + data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end('\n' + data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -667,43 +507,26 @@ app.post('/create', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/create?token=' + token + '&container=' + container
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(() => {
-            res.end('\nSent request to create the containers.');
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/create?token=' + token + '&container=' + container,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(() => {
-            res.end('\nSent request to create the containers.');
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/create?token=' + token + '&container=' + container
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(() => {
-            res.end('\nSent request to create the containers.');
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(() => {
+          res.end('\nSent request to create the containers.');
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -718,37 +541,24 @@ app.get('/rsyslog', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/rsyslog?token=' + token
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/rsyslog?token=' + token,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/rsyslog?token=' + token
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response, body) => {
+      if (!error && response.statusCode === 200) {
+        res.end(body);
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -763,67 +573,34 @@ app.get('/reloadconfig', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/reloadconfig?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          if (process.env.PICLUSTER_CONFIG) {
-            config = JSON.parse(fs.readFileSync(process.env.PICLUSTER_CONFIG, 'utf8'));
-          } else {
-            config = JSON.parse(fs.readFileSync('../config.json', 'utf8'));
-          }
-          token = config.token;
-          user = config.web_username;
-          password = config.web_password;
-          server = config.web_connect;
-          server_port = config.server_port;
-          res.end('\nRequest to update configuration succeeded.');
-        } else {
-          res.end('\nError connecting with server.' + error);
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/reloadconfig?token=' + token,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          if (process.env.PICLUSTER_CONFIG) {
-            config = JSON.parse(fs.readFileSync(process.env.PICLUSTER_CONFIG, 'utf8'));
-          } else {
-            config = JSON.parse(fs.readFileSync('../config.json', 'utf8'));
-          }
-          token = config.token;
-          user = config.web_username;
-          password = config.web_password;
-          server = config.web_connect;
-          server_port = config.server_port;
-          res.end('\nRequest to update configuration succeeded.');
-        } else {
-          res.end('\nError connecting with server.' + error);
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/reloadconfig?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          if (process.env.PICLUSTER_CONFIG) {
-            config = JSON.parse(fs.readFileSync(process.env.PICLUSTER_CONFIG, 'utf8'));
-          } else {
-            config = JSON.parse(fs.readFileSync('../config.json', 'utf8'));
-          }
-          token = config.token;
-          user = config.web_username;
-          password = config.web_password;
-          server = config.web_connect;
-          server_port = config.server_port;
-          res.end('\nRequest to update configuration succeeded.');
-        } else {
-          res.end('\nError connecting with server.' + error);
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        if (process.env.PICLUSTER_CONFIG) {
+          config = JSON.parse(fs.readFileSync(process.env.PICLUSTER_CONFIG, 'utf8'));
+        } else {
+          config = JSON.parse(fs.readFileSync('../config.json', 'utf8'));
+        }
+        token = config.token;
+        user = config.web_username;
+        password = config.web_password;
+        server = config.web_connect;
+        server_port = config.server_port;
+        res.end('\nRequest to update configuration succeeded.');
+      } else {
+        res.end('\nError connecting with server.' + error);
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -838,43 +615,26 @@ app.get('/killvip', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/killvip?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/killvip?token=' + token,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/killvip?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -891,96 +651,43 @@ app.post('/delete-image', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      // FixMe: This isn't a massive issue but should still probably be fixed at some point.
-      if (image.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+    if (config.ssl && image.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image
+      };
+    } else if (config.ssl) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token
+      };
+    } else if (config.ssl && config.ssl_self_signed && image.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image,
+        rejectUnauthorized: 'false'
+      };
     } else if (config.ssl && config.ssl_self_signed) {
-      // FixMe: This isn't a massive issue but should still probably be fixed at some point.
-      if (image.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token,
+        rejectUnauthorized: 'false'
+      };
+    } else if (image.length > 1) {
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image
+      };
     } else {
-      // FixMe: This isn't a massive issue but should still probably be fixed at some point.
-      if (image.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/delete-image?token=' + token
+      };
+    }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
         });
       } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/delete-image?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
+        res.end('\nError connecting with server.');
       }
-    }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -998,90 +705,41 @@ app.post('/build', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      // FixMe: Same as above - Not a massive issue but restructure this at some point in time.
-      if (image.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          }
-        });
-      }
+    if (config.ssl && image.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache
+      };
+    } else if (config.ssl) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache
+      };
+    } else if (config.ssl && config.ssl_self_signed && image.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache,
+        rejectUnauthorized: 'false'
+      };
     } else if (config.ssl && config.ssl_self_signed) {
-      // FixMe: Same as above - Not a massive issue but restructure this at some point in time.
-      if (image.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          }
-        });
-      }
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache,
+        rejectUnauthorized: 'false'
+      };
+    } else if (image.length > 1) {
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache
+      };
     } else {
-      // FixMe: Same as above - Not a massive issue but restructure this at some point in time.
-      if (image.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          }
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache
+      };
+    }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
         });
       }
-    }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1101,96 +759,43 @@ app.post('/delete', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-ifr
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+    if (config.ssl && continainer.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container
+      };
+    } else if (config.ssl) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete?token=' + token
+      };
+    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container,
+        rejectUnauthorized: 'false'
+      };
     } else if (config.ssl && config.ssl_self_signed) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-ifr
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/delete?token=' + token,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/delete?token=' + token,
+        rejectUnauthorized: 'false'
+      };
+    } else if (container.length > 1) {
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container
+      };
     } else {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/delete?token=' + token
+      };
+    }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
         });
       } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/delete?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
+        res.end('\nError connecting with server.');
       }
-    }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1205,43 +810,27 @@ app.get('/prune', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/prune?token=' + token
       };
-      request(options, (error, response, body) => { // eslint-disable-line no-unused-vars
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
+
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/prune?token=' + token,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response, body) => {  // eslint-disable-line no-unused-vars
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/prune?token=' + token
       };
-      request(options, (error, response, body) => {  // eslint-disable-line no-unused-vars
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response, body) => { // eslint-disable-line no-unused-vars
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1261,95 +850,42 @@ app.post('/stop', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/stop?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+    if (config.ssl && container.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container
+      };
+    } else if (config.ssl) {
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/stop?token=' + token
+      };
+    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container,
+        rejectUnauthorized: 'false'
+      };
     } else if (config.ssl && config.ssl_self_signed) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/stop?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/stop?token=' + token
+      };
+    } else if (container.length > 1) {
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container
+      };
     } else {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/stop?token=' + token
+      };
+    }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
         });
       } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/stop?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
+        res.end('\nError connecting with server.');
       }
-    }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1369,49 +905,30 @@ app.post('/changehost', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        request('http://' + server + ':' + server_port + '/changehost?token=' + token + '&container=' + container + '&newhost=' + newhost, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            request(`http://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`, (error, response) => {
-              if (!error && response.statusCode === 200) {
-                display_log(data => {
-                  res.end(data);
-                });
-              } else {
-                res.end('\nError connecting with server.');
-              }
-            });
-          }
-        });
-      }
-    } else {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        request('http://' + server + ':' + server_port + '/changehost?token=' + token + '&container=' + container + '&newhost=' + newhost, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          }
+    if (config.ssl && container.length > 1) {
+      const options = {
+        url: `https://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`
+      };
+    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
+      const options = {
+        url: `https://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`,
+        rejectUnauthorized: 'false'
+      };
+    } else if (container.length > 1) {
+      const options = {
+        url: `http://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`
+      };
+    }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
         });
       } else {
-        request(`http://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
+        res.end('\nError connecting with server.');
       }
-    }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1435,26 +952,29 @@ app.post('/addcontainer', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else if ((container) && (container_args) && (host)) {
     if (config.ssl) {
-      request('https://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints
+      };
+    } else if (config.ssl && config.ssl_self_signed) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints,
+        rejectUnauthorized: 'false'
+      };
     } else {
-      request('http://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints
+      };
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   } else {
     res.end('\nError missing some parameters.');
   }
@@ -1469,40 +989,30 @@ function sendFile(file) {
   };
 
   if (config.ssl) {
-    request.post({
+    const options = {
       url: 'https://' + server + ':' + server_port + '/receive-file',
       formData
-    }, err => {
-      if (err) {
-        console.error('upload failed:', err);
-      } else {
-        console.log('Upload successful!');
-      }
-    });
+    };
   } else if (config.ssl && config.ssl_self_signed) {
-    request.post({
+    const options = {
       url: 'https://' + server + ':' + server_port + '/receive-file',
       rejectUnauthorized: 'false',
       formData
-    }, err => {
-      if (err) {
-        console.error('upload failed:', err);
-      } else {
-        console.log('Upload successful!');
-      }
-    });
+    };
   } else {
-    request.post({
+    const options = {
       url: 'http://' + server + ':' + server_port + '/receive-file',
       formData
-    }, err => {
-      if (err) {
-        console.error('upload failed:', err);
-      } else {
-        console.log('Upload successful!');
-      }
-    });
+    };
   }
+
+  request.post({options}, err => {
+    if (err) {
+      console.error('upload failed:', err);
+    } else {
+      console.log('Upload successful!');
+    }
+  });
 }
 
 app.post('/upload', upload.single('file'), (req, res) => {
@@ -1533,43 +1043,26 @@ app.post('/removecontainerconfig', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   } else {
     res.end('\nError container name.');
   }
@@ -1588,43 +1081,26 @@ app.post('/addhost', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/addhost?token=' + token + '&host=' + host
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/addhost?token=' + token + '&host=' + host,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/addhost?token=' + token + '&host=' + host
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   } else {
     res.end('\nError missing host name.');
   }
@@ -1643,43 +1119,26 @@ app.post('/rmhost', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/rmhost?token=' + token + '&host=' + host
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/rmhost?token=' + token + '&host=' + host,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/rmhost?token=' + token + '&host=' + host
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   } else {
     res.end('\nError missing host name.');
   }
@@ -1699,96 +1158,43 @@ app.post('/start', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/start?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+    if (config.ssl && container.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container
+      };
+    } else if (config.ssl) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/start?token=' + token
+      };
+    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container,
+        rejectUnauthorized: 'false'
+      };
     } else if (config.ssl && config.ssl_self_signed) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/start?token=' + token,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/start?token=' + token,
+        rejectUnauthorized: 'false'
+      };
+    } else if (container.length > 1) {
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container
+      };
     } else {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/start?token=' + token
+      };
+    }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
         });
       } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/start?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
+        res.end('\nError connecting with server.');
       }
-    }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1808,96 +1214,43 @@ app.post('/restart', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/restart?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+    if (config.ssl && container.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container
+      };
+    } else if (config.ssl) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/restart?token=' + token
+      };
+    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container,
+        rejectUnauthorized: 'false'
+      };
     } else if (config.ssl && config.ssl_self_signed) {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      } else {
-        const options = {
-          url: 'https://' + server + ':' + server_port + '/restart?token=' + token,
-          rejectUnauthorized: 'false'
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
-      }
+      const options = {
+        url: 'https://' + server + ':' + server_port + '/restart?token=' + token,
+        rejectUnauthorized: 'false'
+      };
+    } else if (container.length > 1) {
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container
+      };
     } else {
-      // FixMe: Fix this!
-      if (container.length > 1) { // eslint-disable-line no-lonely-if
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
+      const options = {
+        url: 'http://' + server + ':' + server_port + '/restart?token=' + token
+      };
+    }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
         });
       } else {
-        const options = {
-          url: 'http://' + server + ':' + server_port + '/restart?token=' + token
-        };
-        request(options, (error, response) => {
-          if (!error && response.statusCode === 200) {
-            display_log(data => {
-              res.end(data);
-            });
-          } else {
-            res.end('\nError connecting with server.');
-          }
-        });
+        res.end('\nError connecting with server.');
       }
-    }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1912,43 +1265,26 @@ app.get('/hb', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/hb?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/hb?token=' + token,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/hb?token=' + token
       };
-      request(options, (error, response) => {
-        if (!error && response.statusCode === 200) {
-          display_log(data => {
-            res.end(data);
-          });
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response) => {
+      if (!error && response.statusCode === 200) {
+        display_log(data => {
+          res.end(data);
+        });
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -1963,37 +1299,24 @@ app.get('/log', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/log?token=' + token
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/log?token=' + token,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/log?token=' + token
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('\nError connecting with server.');
-        }
-      });
     }
+
+    request(options, (error, response, body) => {
+      if (!error && response.statusCode === 200) {
+        res.end(body);
+      } else {
+        res.end('\nError connecting with server.');
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */
@@ -2019,37 +1342,24 @@ app.get('/getconfig', (req, res) => {
       const options = {
         url: 'https://' + server + ':' + server_port + '/getconfig?token=' + token
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('Error connecting with server. ' + error);
-        }
-      });
     } else if (config.ssl && config.ssl_self_signed) {
       const options = {
         url: 'https://' + server + ':' + server_port + '/getconfig?token=' + token,
         rejectUnauthorized: 'false'
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('Error connecting with server. ' + error);
-        }
-      });
     } else {
       const options = {
         url: 'http://' + server + ':' + server_port + '/getconfig?token=' + token
       };
-      request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          res.end(body);
-        } else {
-          res.end('Error connecting with server. ' + error);
-        }
-      });
     }
+
+    request(options, (error, response, body) => {
+      if (!error && response.statusCode === 200) {
+        res.end(body);
+      } else {
+        res.end('Error connecting with server. ' + error);
+      }
+    });
   }
 });
 /* eslint-enable no-lonely-if */

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -30,6 +30,7 @@ app.use('/node_modules', express.static(path.join(__dirname, 'node_modules')));
 const upload = multer({
   dest: '../'
 });
+const scheme = config.ssl ? 'https://' : 'http://';
 const request_timeout = 5000;
 const web_port = config.web_port;
 let token = config.token;
@@ -46,19 +47,12 @@ if (config.syslog) {
 
 function getData() {
   setTimeout(() => {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/nodes?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/nodes?token=' + token,
-        rejectUnauthorized: false
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/nodes?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/nodes?token=${token}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -121,40 +115,19 @@ app.post('/sendconfig', (req, res) => {
       token
     });
 
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/updateconfig',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': command.length
-        },
-        body: command,
-        token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/updateconfig',
-        rejectUnauthorized: 'false',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': command.length
-        },
-        body: command,
-        token
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/updateconfig',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': command.length
-        },
-        body: command,
-        token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/updateconfig`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': command.length
+      },
+      body: command,
+      token
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -194,37 +167,19 @@ app.post('/exec', (req, res) => {
       token,
       node
     });
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/exec',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': command.length
-        },
-        body: command
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/exec',
-        rejectUnauthorized: 'false',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': command.length
-        },
-        body: command
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/exec',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': command.length
-        },
-        body: command
-      };
+
+    const options = {
+      url: `${scheme}${server}:${server_port}/exec`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': command.length
+      },
+      body: command
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, error => {
@@ -357,37 +312,18 @@ app.post('/listcommands', (req, res) => {
       token
     });
 
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/listcommands',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': token_body.length
-        },
-        body: token_body
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/listcommands',
-        rejectUnauthorized: 'false',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': token_body.length
-        },
-        body: token_body
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/listcommands',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': token_body.length
-        },
-        body: token_body
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/listcommands`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': token_body.length
+      },
+      body: token_body
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -401,19 +337,12 @@ app.post('/listcommands', (req, res) => {
 });
 
 function display_log(callback) {
-  if (config.ssl) {
-    const options = {
-      url: 'https://' + server + ':' + server_port + '/log?token=' + token
-    };
-  } else if (config.ssl && config.ssl_self_signed) {
-    const options = {
-      url: 'https://' + server + ':' + server_port + '/log?token=' + token,
-      rejectUnauthorized: 'false'
-    };
-  } else {
-    const options = {
-      url: 'http://' + server + ':' + server_port + '/log?token=' + token
-    };
+  const options = {
+    url: `${scheme}${server}:${server_port}/log?token=${token}`
+  };
+
+  if (config.ssl_self_signed) {
+    options.rejectUnauthorized = 'false';
   }
 
   clear_log(() => {
@@ -430,19 +359,12 @@ function display_log(callback) {
 }
 
 function clear_log(callback) {
-  if (config.ssl) {
-    const options = {
-      url: 'https://' + server + ':' + server_port + '/clearlog?token=' + token
-    };
-  } else if (config.ssl && config.ssl_self_signed) {
-    const options = {
-      url: 'https://' + server + ':' + server_port + '/clearlog?token=' + token,
-      rejectUnauthorized: 'false'
-    };
-  } else {
-    const options = {
-      url: 'http://' + server + ':' + server_port + '/clearlog?token=' + token
-    };
+  const options = {
+    url: `${scheme}${server}:${server_port}/clearlog?token=${token}`
+  };
+
+  if (config.ssl_self_signed) {
+    options.rejectUnauthorized = 'false';
   }
 
   request(options, (error, response) => {
@@ -464,19 +386,12 @@ app.post('/containerlog', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/containerlog?token=' + token + '&container=' + container
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/containerlog?token=' + token + '&container=' + container,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/containerlog?token=' + token + '&container=' + container
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/containerlog?token=${token}&container=${container}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -503,19 +418,12 @@ app.post('/create', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/create?token=' + token + '&container=' + container
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/create?token=' + token + '&container=' + container,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/create?token=' + token + '&container=' + container
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/create?token=${token}&container=${container}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -537,19 +445,12 @@ app.get('/rsyslog', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/rsyslog?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/rsyslog?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/rsyslog?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/rsyslog?token=${token}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -569,19 +470,12 @@ app.get('/reloadconfig', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/reloadconfig?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/reloadconfig?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/reloadconfig?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/reloadconfig?token=${token}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -611,19 +505,12 @@ app.get('/killvip', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/killvip?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/killvip?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/killvip?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/killvip?token=${token}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -651,32 +538,10 @@ app.post('/delete-image', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl && image.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image
-      };
-    } else if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed && image.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image,
-        rejectUnauthorized: 'false'
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete-image?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else if (image.length > 1) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/delete-image?token=' + token + '&image=' + image
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/delete-image?token=' + token
-      };
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/delete-image?token=${token}&image=${image}`} : {url: `${scheme}${server}:${server_port}/delete-image?token=${token}`};
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -705,32 +570,10 @@ app.post('/build', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl && image.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache
-      };
-    } else if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache
-      };
-    } else if (config.ssl && config.ssl_self_signed && image.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache,
-        rejectUnauthorized: 'false'
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache,
-        rejectUnauthorized: 'false'
-      };
-    } else if (image.length > 1) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/build?token=' + token + '&image=' + image + '&no_cache=' + no_cache
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/build?token=' + token + '&no_cache=' + no_cache
-      };
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/build?token=${token}&image=${image}&no_cache=${no_cache}`} : {url: `${scheme}${server}:${server_port}/build?token=${token}&no_cache=${no_cache}`};
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -759,32 +602,10 @@ app.post('/delete', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl && continainer.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container
-      };
-    } else if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container,
-        rejectUnauthorized: 'false'
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/delete?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else if (container.length > 1) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/delete?token=' + token + '&container=' + container
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/delete?token=' + token
-      };
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/delete?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/delete?token=${token}`};
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -806,20 +627,12 @@ app.get('/prune', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/prune?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/prune?token=${token}`
+    };
 
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/prune?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/prune?token=' + token
-      };
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response, body) => { // eslint-disable-line no-unused-vars
@@ -850,31 +663,10 @@ app.post('/stop', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl && container.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container
-      };
-    } else if (config.ssl) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/stop?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container,
-        rejectUnauthorized: 'false'
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/stop?token=' + token
-      };
-    } else if (container.length > 1) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/stop?token=' + token + '&container=' + container
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/stop?token=' + token
-      };
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/stop?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/stop?token=${token}`};
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -905,19 +697,12 @@ app.post('/changehost', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl && container.length > 1) {
-      const options = {
-        url: `https://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`
-      };
-    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
-      const options = {
-        url: `https://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`,
-        rejectUnauthorized: 'false'
-      };
-    } else if (container.length > 1) {
-      const options = {
-        url: `http://${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -951,19 +736,12 @@ app.post('/addcontainer', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else if ((container) && (container_args) && (host)) {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/addcontainer?token=' + token + '&container=' + container + '&host=' + host + '&container_args=' + container_args + '&heartbeat_args=' + heartbeat_args + '&failover_constraints=' + failover_constraints
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/addcontainer?token=${token}&container=${container}&host=${host}&container_args=${container_args}&heartbeat_args=${heartbeat_args}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -987,23 +765,13 @@ function sendFile(file) {
     token,
     file: fs.createReadStream(file)
   };
+  const options = {
+    url: `${scheme}${server}:${server_port}/receive-file`,
+    formData
+  };
 
-  if (config.ssl) {
-    const options = {
-      url: 'https://' + server + ':' + server_port + '/receive-file',
-      formData
-    };
-  } else if (config.ssl && config.ssl_self_signed) {
-    const options = {
-      url: 'https://' + server + ':' + server_port + '/receive-file',
-      rejectUnauthorized: 'false',
-      formData
-    };
-  } else {
-    const options = {
-      url: 'http://' + server + ':' + server_port + '/receive-file',
-      formData
-    };
+  if (config.ssl_self_signed) {
+    options.rejectUnauthorized = 'false';
   }
 
   request.post({options}, err => {
@@ -1039,19 +807,12 @@ app.post('/removecontainerconfig', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else if (container) {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container
-      };
+    const options = {
+      url: 'http://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -1077,19 +838,12 @@ app.post('/addhost', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else if (host) {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/addhost?token=' + token + '&host=' + host
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/addhost?token=' + token + '&host=' + host,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/addhost?token=' + token + '&host=' + host
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/addhost?token=${token}&host=${host}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -1115,19 +869,12 @@ app.post('/rmhost', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else if (host) {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/rmhost?token=' + token + '&host=' + host
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/rmhost?token=' + token + '&host=' + host,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/rmhost?token=' + token + '&host=' + host
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/rmhost?token=${token}&host=${host}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -1158,32 +905,10 @@ app.post('/start', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl && container.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container
-      };
-    } else if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/start?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container,
-        rejectUnauthorized: 'false'
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/start?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else if (container.length > 1) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/start?token=' + token + '&container=' + container
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/start?token=' + token
-      };
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/start?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/start?token=${token}`};
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -1214,32 +939,10 @@ app.post('/restart', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl && container.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container
-      };
-    } else if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/restart?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed && container.length > 1) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container,
-        rejectUnauthorized: 'false'
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/restart?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else if (container.length > 1) {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/restart?token=' + token + '&container=' + container
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/restart?token=' + token
-      };
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/restart?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/restart?token=${token}`};
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -1261,19 +964,12 @@ app.get('/hb', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/hb?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/hb?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/hb?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/hb?token=${token}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response) => {
@@ -1295,19 +991,12 @@ app.get('/log', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/log?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/log?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/log?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/log?token=${token}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -1338,19 +1027,12 @@ app.get('/getconfig', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    if (config.ssl) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/getconfig?token=' + token
-      };
-    } else if (config.ssl && config.ssl_self_signed) {
-      const options = {
-        url: 'https://' + server + ':' + server_port + '/getconfig?token=' + token,
-        rejectUnauthorized: 'false'
-      };
-    } else {
-      const options = {
-        url: 'http://' + server + ':' + server_port + '/getconfig?token=' + token
-      };
+    const options = {
+      url: `${scheme}${server}:${server_port}/getconfig?token=${token}`
+    };
+
+    if (config.ssl_self_signed) {
+      options.rejectUnauthorized = 'false';
     }
 
     request(options, (error, response, body) => {

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -31,7 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed !== false;
+const ssl_self_signed = config.ssl_self_signed === false;
 const request_timeout = 5000;
 const web_port = config.web_port;
 let token = config.token;

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -57,21 +57,15 @@ function getData() {
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
-        /* eslint-disable no-unused-vars */
-        let json;
-        let statusCode = 200;
         try {
           nodedata = JSON.parse(response.body);
         } catch (err) {
-          statusCode = 500;
           console.error(err);
         }
-        /* eslint-enable no-unused-vars */
       } else {
         console.log('\nError connecting with server. ' + error);
       }
     });
-
     getData();
   }, 5000);
 }
@@ -216,16 +210,16 @@ app.get('/listregistries', (req, res) => {
 });
 
 app.get('/remoteimagetags', (req, res) => {
-  const check_token = req.query.token;
-  if (!check_token || check_token !== token) {
-    return res.status(401).end('\nError: Invalid Credentials');
-  }
-
   const registry = req.query.registry;
   const image = req.query.image;
   const page = req.query.page || 1;
   const username = req.query.username || '';
   const password = req.query.password || '';
+  const check_token = req.query.token;
+
+  if (!check_token || check_token !== token) {
+    return res.status(401).end('\nError: Invalid Credentials');
+  }
 
   if (!registry || !image) {
     return res.status(400).end('\nError: Invalid Credentials');
@@ -253,6 +247,7 @@ app.get('/remoteimagetags', (req, res) => {
     if (!error && response.statusCode !== 200) {
       error = body;
     }
+
     res.status(response.statusCode).end((error) ? JSON.stringify({
       error: error.toString()
     }) : body);
@@ -260,16 +255,16 @@ app.get('/remoteimagetags', (req, res) => {
 });
 
 app.get('/remoteimages', (req, res) => {
-  const check_token = req.query.token;
-  if (!check_token || check_token !== token) {
-    return res.status(401).end('\nError: Invalid Credentials');
-  }
-
   const registry = req.query.registry;
   const image = req.query.image;
   const page = req.query.page || 1;
   const username = req.query.username || '';
   const password = req.query.password || '';
+  const check_token = req.query.token;
+
+  if (!check_token || check_token !== token) {
+    return res.status(401).end('\nError: Invalid Credentials');
+  }
 
   if (!registry || !image) {
     return res.status(400).end('\nError: Bad Request');
@@ -297,6 +292,7 @@ app.get('/remoteimages', (req, res) => {
     if (!error && response.statusCode !== 200) {
       error = body;
     }
+
     res.status(response.statusCode).end((error) ? JSON.stringify({
       error: error.toString()
     }) : body);
@@ -305,6 +301,7 @@ app.get('/remoteimages', (req, res) => {
 
 app.post('/listcommands', (req, res) => {
   const check_token = req.body.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -376,7 +373,6 @@ function clear_log(callback) {
   });
 }
 
-/* eslint-disable no-lonely-if */
 app.post('/containerlog', (req, res) => {
   const check_token = req.body.token;
   let container = '';
@@ -405,9 +401,7 @@ app.post('/containerlog', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/create', (req, res) => {
   const check_token = req.body.token;
   let container = '';
@@ -415,6 +409,7 @@ app.post('/create', (req, res) => {
   if (req.body.token) {
     container = req.body.container;
   }
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -437,11 +432,10 @@ app.post('/create', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/rsyslog', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -462,11 +456,10 @@ app.get('/rsyslog', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/reloadconfig', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -497,11 +490,10 @@ app.get('/reloadconfig', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/killvip', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -524,9 +516,7 @@ app.get('/killvip', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/delete-image', (req, res) => {
   const check_token = req.body.token;
   let image = req.body.image;
@@ -555,9 +545,7 @@ app.post('/delete-image', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/build', (req, res) => {
   const check_token = req.body.token;
   let image = req.body.image;
@@ -585,9 +573,7 @@ app.post('/build', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/delete', (req, res) => {
   const check_token = req.body.token;
   let container = '';
@@ -619,11 +605,10 @@ app.post('/delete', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/prune', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -646,9 +631,7 @@ app.get('/prune', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/stop', (req, res) => {
   const check_token = req.body.token;
   let container = '';
@@ -680,13 +663,12 @@ app.post('/stop', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/changehost', (req, res) => {
   const check_token = req.body.token;
   const newhost = req.body.newhost;
   let container;
+
   if (req.body.container) {
     container = req.body.container;
     if (container.indexOf('Everything') > -1) {
@@ -716,9 +698,7 @@ app.post('/changehost', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/addcontainer', (req, res) => {
   const check_token = req.body.token;
   const host = req.body.host;
@@ -757,7 +737,6 @@ app.post('/addcontainer', (req, res) => {
     res.end('\nError missing some parameters.');
   }
 });
-/* eslint-enable no-lonely-if */
 
 function sendFile(file) {
   const formData = {
@@ -765,6 +744,7 @@ function sendFile(file) {
     token,
     file: fs.createReadStream(file)
   };
+
   const options = {
     url: `${scheme}${server}:${server_port}/receive-file`,
     formData
@@ -785,6 +765,7 @@ function sendFile(file) {
 
 app.post('/upload', upload.single('file'), (req, res) => {
   const check_token = req.body.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -799,7 +780,6 @@ app.post('/upload', upload.single('file'), (req, res) => {
   }
 });
 
-/* eslint-disable no-lonely-if */
 app.post('/removecontainerconfig', (req, res) => {
   const check_token = req.body.token;
   const container = req.body.container;
@@ -828,9 +808,7 @@ app.post('/removecontainerconfig', (req, res) => {
     res.end('\nError container name.');
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/addhost', (req, res) => {
   const check_token = req.body.token;
   const host = req.body.host;
@@ -859,9 +837,7 @@ app.post('/addhost', (req, res) => {
     res.end('\nError missing host name.');
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/rmhost', (req, res) => {
   const check_token = req.body.token;
   const host = req.body.host;
@@ -890,18 +866,18 @@ app.post('/rmhost', (req, res) => {
     res.end('\nError missing host name.');
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/start', (req, res) => {
   const check_token = req.body.token;
   let container;
+
   if (req.body.container) {
     container = req.body.container;
     if (container.indexOf('Everything') > -1) {
       container = '';
     }
   }
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -922,9 +898,7 @@ app.post('/start', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.post('/restart', (req, res) => {
   const check_token = req.body.token;
   let container;
@@ -956,11 +930,10 @@ app.post('/restart', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/hb', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -983,11 +956,10 @@ app.get('/hb', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/log', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1008,22 +980,20 @@ app.get('/log', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/nodes', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
     res.json(nodedata);
   }
 });
-/* eslint-enable no-lonely-if */
 
-/* eslint-disable no-lonely-if */
 app.get('/getconfig', (req, res) => {
   const check_token = req.query.token;
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
@@ -1044,7 +1014,6 @@ app.get('/getconfig', (req, res) => {
     });
   }
 });
-/* eslint-enable no-lonely-if */
 
 app.get('/', (req, res) => {
   res.sendFile(__dirname + '/main.html');

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -31,7 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
-const ssl_self_signed = config.ssl_self_signed ? false : true;
+const ssl_self_signed = config.ssl_self_signed !== false;
 const request_timeout = 5000;
 const web_port = config.web_port;
 let token = config.token;

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -31,6 +31,7 @@ const upload = multer({
   dest: '../'
 });
 const scheme = config.ssl ? 'https://' : 'http://';
+const ssl_self_signed = config.ssl_self_signed ? 'false' : 'true';
 const request_timeout = 5000;
 const web_port = config.web_port;
 let token = config.token;
@@ -48,12 +49,9 @@ if (config.syslog) {
 function getData() {
   setTimeout(() => {
     const options = {
-      url: `${scheme}${server}:${server_port}/nodes?token=${token}`
+      url: `${scheme}${server}:${server_port}/nodes?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -111,6 +109,7 @@ app.post('/sendconfig', (req, res) => {
 
     const options = {
       url: `${scheme}${server}:${server_port}/updateconfig`,
+      rejectUnauthorized: ssl_self_signed,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -119,10 +118,6 @@ app.post('/sendconfig', (req, res) => {
       body: command,
       token
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => {
       if (error) {
@@ -164,6 +159,7 @@ app.post('/exec', (req, res) => {
 
     const options = {
       url: `${scheme}${server}:${server_port}/exec`,
+      rejectUnauthorized: ssl_self_signed,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -171,10 +167,6 @@ app.post('/exec', (req, res) => {
       },
       body: command
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, error => {
       if (error) {
@@ -311,6 +303,7 @@ app.post('/listcommands', (req, res) => {
 
     const options = {
       url: `${scheme}${server}:${server_port}/listcommands`,
+      rejectUnauthorized: ssl_self_signed,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -318,10 +311,6 @@ app.post('/listcommands', (req, res) => {
       },
       body: token_body
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => {
       if (error) {
@@ -335,12 +324,9 @@ app.post('/listcommands', (req, res) => {
 
 function display_log(callback) {
   const options = {
-    url: `${scheme}${server}:${server_port}/log?token=${token}`
+    url: `${scheme}${server}:${server_port}/log?token=${token}`,
+    rejectUnauthorized: ssl_self_signed
   };
-
-  if (config.ssl_self_signed) {
-    options['rejectUnauthorized'] = 'false';
-  }
 
   clear_log(() => {
     setTimeout(() => {
@@ -357,12 +343,9 @@ function display_log(callback) {
 
 function clear_log(callback) {
   const options = {
-    url: `${scheme}${server}:${server_port}/clearlog?token=${token}`
+    url: `${scheme}${server}:${server_port}/clearlog?token=${token}`,
+    rejectUnauthorized: ssl_self_signed
   };
-
-  if (config.ssl_self_signed) {
-    options['rejectUnauthorized'] = 'false';
-  }
 
   request(options, (error, response) => {
     if (!error && response.statusCode === 200) {
@@ -376,19 +359,18 @@ function clear_log(callback) {
 app.post('/containerlog', (req, res) => {
   const check_token = req.body.token;
   let container = '';
+
   if (req.body.token) {
     container = req.body.container;
   }
+
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/containerlog?token=${token}&container=${container}`
+      url: `${scheme}${server}:${server_port}/containerlog?token=${token}&container=${container}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -414,12 +396,9 @@ app.post('/create', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/create?token=${token}&container=${container}`
+      url: `${scheme}${server}:${server_port}/create?token=${token}&container=${container}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -440,12 +419,9 @@ app.get('/rsyslog', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/rsyslog?token=${token}`
+      url: `${scheme}${server}:${server_port}/rsyslog?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => {
       if (!error && response.statusCode === 200) {
@@ -464,12 +440,9 @@ app.get('/reloadconfig', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/reloadconfig?token=${token}`
+      url: `${scheme}${server}:${server_port}/reloadconfig?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -498,12 +471,9 @@ app.get('/killvip', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/killvip?token=${token}`
+      url: `${scheme}${server}:${server_port}/killvip?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -528,11 +498,7 @@ app.post('/delete-image', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/delete-image?token=${token}&image=${image}`} : {url: `${scheme}${server}:${server_port}/delete-image?token=${token}`};
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/delete-image?token=${token}&image=${image}`, rejectUnauthorized: ssl_self_signed} : {url: `${scheme}${server}:${server_port}/delete-image?token=${token}`, rejectUnauthorized: ssl_self_signed};
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -558,11 +524,7 @@ app.post('/build', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/build?token=${token}&image=${image}&no_cache=${no_cache}`} : {url: `${scheme}${server}:${server_port}/build?token=${token}&no_cache=${no_cache}`};
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
+    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/build?token=${token}&image=${image}&no_cache=${no_cache}`, rejectUnauthorized: ssl_self_signed} : {url: `${scheme}${server}:${server_port}/build?token=${token}&no_cache=${no_cache}`, rejectUnauthorized: ssl_self_signed};
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -588,11 +550,7 @@ app.post('/delete', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/delete?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/delete?token=${token}`};
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/delete?token=${token}&container=${container}`, rejectUnauthorized: ssl_self_signed} : {url: `${scheme}${server}:${server_port}/delete?token=${token}`, rejectUnauthorized: ssl_self_signed};
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -613,12 +571,9 @@ app.get('/prune', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/prune?token=${token}`
+      url: `${scheme}${server}:${server_port}/prune?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => { // eslint-disable-line no-unused-vars
       if (!error && response.statusCode === 200) {
@@ -646,11 +601,7 @@ app.post('/stop', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/stop?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/stop?token=${token}`};
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/stop?token=${token}&container=${container}`, rejectUnauthorized: ssl_self_signed} : {url: `${scheme}${server}:${server_port}/stop?token=${token}`, rejectUnauthorized: ssl_self_signed};
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -680,12 +631,9 @@ app.post('/changehost', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`
+      url: `${scheme}${server}:${server_port}/changehost?token=${token}&container=${container}&newhost=${newhost}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -717,12 +665,9 @@ app.post('/addcontainer', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else if ((container) && (container_args) && (host)) {
     const options = {
-      url: `${scheme}${server}:${server_port}/addcontainer?token=${token}&container=${container}&host=${host}&container_args=${container_args}&heartbeat_args=${heartbeat_args}`
+      url: `${scheme}${server}:${server_port}/addcontainer?token=${token}&container=${container}&host=${host}&container_args=${container_args}&heartbeat_args=${heartbeat_args}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -747,12 +692,9 @@ function sendFile(file) {
 
   const options = {
     url: `${scheme}${server}:${server_port}/receive-file`,
+    rejectUnauthorized: ssl_self_signed,
     formData
   };
-
-  if (config.ssl_self_signed) {
-    options['rejectUnauthorized'] = 'false';
-  }
 
   request.post({options}, err => {
     if (err) {
@@ -788,12 +730,9 @@ app.post('/removecontainerconfig', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else if (container) {
     const options = {
-      url: 'http://' + server + ':' + server_port + '/removecontainerconfig?token=' + token + '&container=' + container
+      url: `${scheme}${server}:${server_port}/removecontainerconfig?token=${token}&container=${container}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -817,12 +756,9 @@ app.post('/addhost', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else if (host) {
     const options = {
-      url: `${scheme}${server}:${server_port}/addhost?token=${token}&host=${host}`
+      url: `${scheme}${server}:${server_port}/addhost?token=${token}&host=${host}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -846,12 +782,9 @@ app.post('/rmhost', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else if (host) {
     const options = {
-      url: `${scheme}${server}:${server_port}/rmhost?token=${token}&host=${host}`
+      url: `${scheme}${server}:${server_port}/rmhost?token=${token}&host=${host}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -881,11 +814,7 @@ app.post('/start', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/start?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/start?token=${token}`};
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/start?token=${token}&container=${container}`, rejectUnauthorized: ssl_self_signed} : {url: `${scheme}${server}:${server_port}/start?token=${token}`, rejectUnauthorized: ssl_self_signed};
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -913,11 +842,7 @@ app.post('/restart', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/restart?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/restart?token=${token}`};
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/restart?token=${token}&container=${container}`, rejectUnauthorized: ssl_self_signed} : {url: `${scheme}${server}:${server_port}/restart?token=${token}`, rejectUnauthorized: ssl_self_signed};
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -938,12 +863,9 @@ app.get('/hb', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/hb?token=${token}`
+      url: `${scheme}${server}:${server_port}/hb?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response) => {
       if (!error && response.statusCode === 200) {
@@ -964,12 +886,9 @@ app.get('/log', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/log?token=${token}`
+      url: `${scheme}${server}:${server_port}/log?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => {
       if (!error && response.statusCode === 200) {
@@ -998,12 +917,9 @@ app.get('/getconfig', (req, res) => {
     res.end('\nError: Invalid Credentials');
   } else {
     const options = {
-      url: `${scheme}${server}:${server_port}/getconfig?token=${token}`
+      url: `${scheme}${server}:${server_port}/getconfig?token=${token}`,
+      rejectUnauthorized: ssl_self_signed
     };
-
-    if (config.ssl_self_signed) {
-      options['rejectUnauthorized'] = 'false';
-    }
 
     request(options, (error, response, body) => {
       if (!error && response.statusCode === 200) {

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -602,7 +602,7 @@ app.post('/delete', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/delete?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/delete?token=${token}`};
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/delete?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/delete?token=${token}`};
 
     if (config.ssl_self_signed) {
       options.rejectUnauthorized = 'false';
@@ -663,7 +663,7 @@ app.post('/stop', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/stop?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/stop?token=${token}`};
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/stop?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/stop?token=${token}`};
 
     if (config.ssl_self_signed) {
       options.rejectUnauthorized = 'false';
@@ -905,7 +905,7 @@ app.post('/start', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/start?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/start?token=${token}`};
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/start?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/start?token=${token}`};
 
     if (config.ssl_self_signed) {
       options.rejectUnauthorized = 'false';
@@ -939,7 +939,7 @@ app.post('/restart', (req, res) => {
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/restart?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/restart?token=${token}`};
+    const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/restart?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/restart?token=${token}`};
 
     if (config.ssl_self_signed) {
       options.rejectUnauthorized = 'false';

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -52,7 +52,7 @@ function getData() {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -121,7 +121,7 @@ app.post('/sendconfig', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -173,7 +173,7 @@ app.post('/exec', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, error => {
@@ -320,7 +320,7 @@ app.post('/listcommands', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -339,7 +339,7 @@ function display_log(callback) {
   };
 
   if (config.ssl_self_signed) {
-    options.rejectUnauthorized = 'false';
+    options['rejectUnauthorized'] = 'false';
   }
 
   clear_log(() => {
@@ -361,7 +361,7 @@ function clear_log(callback) {
   };
 
   if (config.ssl_self_signed) {
-    options.rejectUnauthorized = 'false';
+    options['rejectUnauthorized'] = 'false';
   }
 
   request(options, (error, response) => {
@@ -387,7 +387,7 @@ app.post('/containerlog', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -418,7 +418,7 @@ app.post('/create', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -444,7 +444,7 @@ app.get('/rsyslog', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -468,7 +468,7 @@ app.get('/reloadconfig', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -502,7 +502,7 @@ app.get('/killvip', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -531,7 +531,7 @@ app.post('/delete-image', (req, res) => {
     const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/delete-image?token=${token}&image=${image}`} : {url: `${scheme}${server}:${server_port}/delete-image?token=${token}`};
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -561,7 +561,7 @@ app.post('/build', (req, res) => {
     const options = image.length > 1 ? {url: `${scheme}${server}:${server_port}/build?token=${token}&image=${image}&no_cache=${no_cache}`} : {url: `${scheme}${server}:${server_port}/build?token=${token}&no_cache=${no_cache}`};
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -591,7 +591,7 @@ app.post('/delete', (req, res) => {
     const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/delete?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/delete?token=${token}`};
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -617,7 +617,7 @@ app.get('/prune', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => { // eslint-disable-line no-unused-vars
@@ -649,7 +649,7 @@ app.post('/stop', (req, res) => {
     const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/stop?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/stop?token=${token}`};
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -684,7 +684,7 @@ app.post('/changehost', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -721,7 +721,7 @@ app.post('/addcontainer', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -751,7 +751,7 @@ function sendFile(file) {
   };
 
   if (config.ssl_self_signed) {
-    options.rejectUnauthorized = 'false';
+    options['rejectUnauthorized'] = 'false';
   }
 
   request.post({options}, err => {
@@ -792,7 +792,7 @@ app.post('/removecontainerconfig', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -821,7 +821,7 @@ app.post('/addhost', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -850,7 +850,7 @@ app.post('/rmhost', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -884,7 +884,7 @@ app.post('/start', (req, res) => {
     const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/start?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/start?token=${token}`};
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -916,7 +916,7 @@ app.post('/restart', (req, res) => {
     const options = container.length > 1 ? {url: `${scheme}${server}:${server_port}/restart?token=${token}&container=${container}`} : {url: `${scheme}${server}:${server_port}/restart?token=${token}`};
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -942,7 +942,7 @@ app.get('/hb', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response) => {
@@ -968,7 +968,7 @@ app.get('/log', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => {
@@ -1002,7 +1002,7 @@ app.get('/getconfig', (req, res) => {
     };
 
     if (config.ssl_self_signed) {
-      options.rejectUnauthorized = 'false';
+      options['rejectUnauthorized'] = 'false';
     }
 
     request(options, (error, response, body) => {


### PR DESCRIPTION
After the initial proof of concept, I wanted to refactor the code so it is less bloated and more readable. Use of ternary operators and template literals have reduced the code between the three components by over 2000 loc.

This passes travis, but I'm hoping the rest of the team can help bug hunting. While running `npm test` on picluster, there are about 50 warning that should be addressed.

Also during refactoring I looked at splitting app functions into a library while leaving app logic to their respective components. Unfortunately nodejs does not support including external javascript libraries elegantly, so functions will need to be put in their own nodejs module to get functions separate from component logic.