### PR TITLE
Fix modal overflow cutoff issue and other cool things

### DIFF
--- a/web/addcontainer.html
+++ b/web/addcontainer.html
@@ -38,7 +38,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Add a container to PiCluster</h2>
@@ -74,7 +74,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/addhost.html
+++ b/web/addhost.html
@@ -22,7 +22,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Add a host to PiCluster</h2>

--- a/web/addhost.html
+++ b/web/addhost.html
@@ -22,7 +22,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Add a host to PiCluster</h2>
@@ -42,7 +42,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -86,7 +86,7 @@ table tbody tr td label {
   top: 0;
   height: 100%;
   width: 100%;
-  overflow: scroll;
+  overflow: auto;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.4);
 }
@@ -98,12 +98,19 @@ table tbody tr td label {
   font-size: 12px;
   padding: 0;
   border: 1px solid #888;
-  width: 75%;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   -webkit-animation-name: animatetop;
   -webkit-animation-duration: 0.4s;
   animation-name: animatetop;
   animation-duration: 0.4s
+}
+
+.modal-small {
+  width: 35%;
+}
+
+.modal-medium {
+  width: 75%;
 }
 
 .modal-header {

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -243,3 +243,5 @@ table tbody tr td label {
 #modal-body2 {
   font-size: 18px;
 }
+
+#config_editor

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -244,4 +244,9 @@ table tbody tr td label {
   font-size: 18px;
 }
 
-#config_editor
+#config_editor {
+}
+
+#payload {
+  width: 100%;
+}

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -171,8 +171,8 @@ table tbody tr td label {
 }
 
 .log_type_box {
-  width: 30%;
-  display: inline;
+  width: 15%;
+  display: inline-block;
 }
 
 #log_search {

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -86,7 +86,7 @@ table tbody tr td label {
   top: 0;
   height: 100%;
   width: 100%;
-  overflow: visible;
+  overflow: scroll;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.4);
 }
@@ -99,8 +99,6 @@ table tbody tr td label {
   padding: 0;
   border: 1px solid #888;
   width: 75%;
-  min-height: 75%;
-  height: 100%;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   -webkit-animation-name: animatetop;
   -webkit-animation-duration: 0.4s;

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -90,7 +90,6 @@ table tbody tr td label {
   top: 0;
   height: 100%;
   width: 100%;
-  overflow: scroll;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.4);
 }
@@ -128,7 +127,6 @@ table tbody tr td label {
 .modal-body {
   padding: 1px 10px;
   color: black;
-  overflow-y: scroll;
 }
 
 .close {

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -9,7 +9,7 @@ body {
   padding: 0px;
   margin: 0px;
   font-size: 1rem;
-  height: auto;
+  height: 100%;
 }
 
 button {
@@ -100,7 +100,7 @@ table tbody tr td label {
   border: 1px solid #888;
   width: 75%;
   min-height: 75%;
-  height: auto;
+  height: 100%;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   -webkit-animation-name: animatetop;
   -webkit-animation-duration: 0.4s;

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -83,7 +83,7 @@ table tbody tr td label {
 
 .modal {
   display: none;
-  position: fixed;
+  position: relative;
   z-index: 1;
   padding-top: 5vw;
   left: 0;

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -110,11 +110,13 @@ table tbody tr td label {
 }
 
 .modal-small {
-  width: 35%;
+  width: 44%;
+  min-width: 370px
 }
 
 .modal-medium {
   width: 75%;
+  min-width: 600px;
 }
 
 .modal-header {
@@ -163,8 +165,7 @@ table tbody tr td label {
   *zoom: 1;
 }
 
-.node_card {
-}
+.node_card {}
 
 .page {
   margin: 10px;
@@ -195,20 +196,13 @@ table tbody tr td label {
   text-align: center;
 }
 
-#log_type_error {
+#log_type_error {}
 
-}
+#log_type_failure {}
 
-#log_type_failure {
+#log_type_warning {}
 
-}
-
-#log_type_warning {
-
-}
-#log_type_today {
-
-}
+#log_type_today {}
 
 #log_output {
   width: 100%;
@@ -260,6 +254,12 @@ table tbody tr td label {
   font-size: 18px;
 }
 
+#function_output {
+  width: 100%;
+}
+
+#function_url {}
+
 #node_list {
   font-size: 18px;
 }
@@ -284,8 +284,7 @@ table tbody tr td label {
   font-size: 18px;
 }
 
-#config_editor {
-}
+#config_editor {}
 
 #payload {
   width: 100%;

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -86,7 +86,7 @@ table tbody tr td label {
   top: 0;
   height: 100%;
   width: 100%;
-  overflow: visible;
+  overflow: scroll;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.4);
 }
@@ -109,6 +109,17 @@ table tbody tr td label {
   animation-duration: 0.4s
 }
 
+.modal-header {
+  padding: 2px 16px;
+  background-color: #565051;
+  color: white;
+}
+
+.modal-body {
+  padding: 2px 16px;
+  color: black
+}
+
 .close {
   color: white;
   float: right;
@@ -121,17 +132,6 @@ table tbody tr td label {
   color: #000;
   text-decoration: none;
   cursor: pointer;
-}
-
-.modal-header {
-  padding: 2px 16px;
-  background-color: #565051;
-  color: white;
-}
-
-.modal-body {
-  padding: 2px 16px;
-  color: black
 }
 
 .dark-area {

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -39,6 +39,10 @@ h1 {
   margin: 40px 0 60px 0;
 }
 
+h2 {
+  margin: .4em;
+}
+
 label {
   font-size: 18px;
 }
@@ -120,7 +124,7 @@ table tbody tr td label {
 }
 
 .modal-body {
-  padding: 2px 16px;
+  padding: 1px 10px;
   color: black
 }
 
@@ -173,6 +177,7 @@ table tbody tr td label {
 
 #log_search {
   width: 100%;
+  text-align: center;
 }
 
 #log_search_bar {
@@ -187,6 +192,7 @@ table tbody tr td label {
 
 #log_type {
   width: 100%;
+  text-align: center;
 }
 
 #log_type_error {
@@ -205,7 +211,7 @@ table tbody tr td label {
 }
 
 #log_output {
-  width: 10%;
+  width: 100%;
 }
 
 #upload-widget {

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -90,7 +90,7 @@ table tbody tr td label {
   top: 0;
   height: 100%;
   width: 100%;
-  overflow: auto;
+  overflow: scroll;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.4);
 }

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -166,12 +166,42 @@ table tbody tr td label {
   margin: 10px;
 }
 
+.log_type_box {
+  width: 30%;
+  display: inline;
+}
+
 #log_search {
-  width: 10%;
+  width: 100%;
+}
+
+#log_search_bar {
+  width:30%;
+  display: inline;
+}
+
+#log_search_button {
+  width: 30%;
+  display: inline;
 }
 
 #log_type {
-  width: 42%;
+  width: 100%;
+}
+
+#log_type_error {
+
+}
+
+#log_type_failure {
+
+}
+
+#log_type_warning {
+
+}
+#log_type_today {
+
 }
 
 #log_output {
@@ -234,6 +264,10 @@ table tbody tr td label {
 
 #command_entry {
   font-size: 18px;
+}
+
+#command_output {
+  width: 100%;
 }
 
 #windowfont {

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -127,7 +127,8 @@ table tbody tr td label {
 
 .modal-body {
   padding: 1px 10px;
-  color: black
+  color: black;
+  overflow-y: scroll;
 }
 
 .close {

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -86,7 +86,7 @@ table tbody tr td label {
   top: 0;
   height: 100%;
   width: 100%;
-  overflow: scroll;
+  overflow: visible;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.4);
 }
@@ -101,7 +101,6 @@ table tbody tr td label {
   width: 75%;
   min-height: 75%;
   height: auto;
-  overflow: auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   -webkit-animation-name: animatetop;
   -webkit-animation-duration: 0.4s;

--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -85,7 +85,7 @@ table tbody tr td label {
   display: none;
   position: fixed;
   z-index: 1;
-  padding-top: 5px;
+  padding-top: 5vw;
   left: 0;
   top: 0;
   height: 100%;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -1,5 +1,4 @@
 html {
-  min-height: 100%;
   font-family: 'Nunito', sans-serif;
   -webkit-font-smoothing: antialiased;
 }
@@ -13,8 +12,7 @@ body {
   margin: 0px;
   line-height: 18px;
   color: #333333;
-  min-height: 100%;
-  overflow: auto;
+  height: auto;
 }
 
 iframe {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -166,6 +166,20 @@ textarea {
   border-bottom: 8px solid #F6F7F9;
 }
 
+.login-modal {
+  display: block;
+  position: fixed;
+  z-index: 1;
+  padding-top: 100px;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
 /*
 .modal {
   display: none;
@@ -224,17 +238,6 @@ textarea {
 }
 
 #login {
-  display: block;
-  position: fixed;
-  z-index: 1;
-  padding-top: 100px;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: scroll;
-  background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, 0.4);
 }
 
 #div_iframe {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -232,7 +232,7 @@ textarea {
 #div_iframe {
   padding-top: 1vw;
   width:100%;
-  height: calc(100% - 1vw);
+  height: 100%;
   z-index: -1;
 }
 

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -223,6 +223,20 @@ textarea {
   cursor: pointer;
 }
 
+#login {
+  display: block;
+  position: fixed;
+  z-index: 1;
+  padding-top: 100px;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
 #div_iframe {
   width:100%;
   height: 100%;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -235,7 +235,7 @@ textarea {
 #iframe_a {
   display: block;
   border-width: 0px;
-  height: 100%
+  height: 100%;
   width:100%;
   overflow-y: scroll;
 }

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -60,7 +60,7 @@ nav ul li {
 }
 
 nav ul li a {
-  padding: 1.4rem 0.6rem;
+  padding: 1vw;
   display: block;
   color: rgba(255, 255, 255, .9);
   text-decoration: none;
@@ -247,6 +247,6 @@ textarea {
 }
 
 #nav_logo {
-  height: 65px;
-  width: 65px;
+  height: 4vw;
+  width: 4vw;
 }

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -223,15 +223,14 @@ textarea {
 #menu {
   position: fixed;
   width: 100%;
-  z-index: 10;
+  z-index: 1;
 }
 
 #login {}
 
 #div_iframe {
-  padding-top: 4vw;
   width:100%;
-  height: calc(100% - 1vw);
+  height: calc(100% - 4vw);
   z-index: -1;
 }
 

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -234,6 +234,7 @@ textarea {
   border-width: 0px;
   width:100%;
   height:100%;
+  margin-bottom: 5%;
 }
 
 #logo {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -222,14 +222,14 @@ textarea {
 }
 
 #div_iframe {
-  position: relative;
+  position: fixed;
   width:100%;
   height:100%;
   z-index: -1;
 }
 
 #iframe_a {
-  position: fixed;
+  position: relative;
   display: block;
   border-width: 0px;
   width:100%;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -230,9 +230,9 @@ textarea {
 }
 
 #div_iframe {
-  padding-top: 65px;
+  padding-top: 1vw;
   width:100%;
-  height: calc(100% - 65px);
+  height: calc(100% - 1vw);
   z-index: -1;
 }
 

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -163,7 +163,6 @@ textarea {
   border: 1px solid #888;
   min-width: 280px;
   width: 25%;
-  overflow: auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   -webkit-animation-name: animatetop;
   -webkit-animation-duration: 0.4s;
@@ -232,7 +231,6 @@ textarea {
   width:100%;
   height: calc(100% - 1vw);
   z-index: -1;
-  overflow-y: scroll;
 }
 
 #iframe_a {
@@ -240,7 +238,9 @@ textarea {
   border-width: 0px;
   height: 100%;
   width:100%;
-
+  position: absolute;
+  z-index: -1;
+  overflow-y: scroll;
 }
 
 #logo {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -220,6 +220,10 @@ textarea {
   cursor: pointer;
 }
 
+#menu {
+
+}
+
 #login {
 }
 
@@ -233,8 +237,6 @@ textarea {
   display: block;
   border-width: 0px;
   width:100%;
-  height:100%;
-  margin-bottom: 5%;
 }
 
 #logo {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -2,6 +2,7 @@ html {
   font-family: 'Nunito', sans-serif;
   -webkit-font-smoothing: antialiased;
   height: 100%;
+  overflow: hidden;
 }
 
 body {
@@ -14,6 +15,7 @@ body {
   line-height: 18px;
   color: #333333;
   height: 100%;
+  overflow: hidden;
 }
 
 h1 {
@@ -230,6 +232,7 @@ textarea {
   width:100%;
   height: calc(100% - 1vw);
   z-index: -1;
+  overflow-y: scroll;
 }
 
 #iframe_a {
@@ -237,7 +240,7 @@ textarea {
   border-width: 0px;
   height: 100%;
   width:100%;
-  overflow-y: scroll;
+
 }
 
 #logo {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -232,7 +232,7 @@ textarea {
 #div_iframe {
   padding-top: 65px;
   width:100%;
-  max-height: 100%;
+  height: calc(100% - 65px);
   z-index: -1;
 }
 

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -222,14 +222,12 @@ textarea {
 }
 
 #div_iframe {
-  position: fixed;
   width:100%;
-  height:100%;
+  height:auto;
   z-index: -1;
 }
 
 #iframe_a {
-  position: relative;
   display: block;
   border-width: 0px;
   width:100%;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -16,10 +16,6 @@ body {
   height: 100%;
 }
 
-iframe {
-  height: 100%;
-}
-
 h1 {
   font-weight: 200;
   font-size: 3rem;
@@ -239,7 +235,9 @@ textarea {
 #iframe_a {
   display: block;
   border-width: 0px;
+  height: 100%
   width:100%;
+  overflow-y: scroll;
 }
 
 #logo {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -1,6 +1,7 @@
 html {
   font-family: 'Nunito', sans-serif;
   -webkit-font-smoothing: antialiased;
+  height: 100%;
 }
 
 body {
@@ -12,7 +13,7 @@ body {
   margin: 0px;
   line-height: 18px;
   color: #333333;
-  height: auto;
+  height: 100%;
 }
 
 iframe {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -229,6 +229,7 @@ textarea {
 #login {}
 
 #div_iframe {
+  margin-top: 4vw;
   width:100%;
   height: calc(100% - 4vw);
   z-index: -1;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -222,12 +222,14 @@ textarea {
 }
 
 #div_iframe {
+  position: relative;
   width:100%;
   height:100%;
   z-index: -1;
 }
 
 #iframe_a {
+  position: fixed;
   display: block;
   border-width: 0px;
   width:100%;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -38,6 +38,7 @@ nav {
   max-width: 100%;
   max-height: 100%;
   background: #565051;
+  z-index: 10;
 }
 
 nav::after {
@@ -239,7 +240,6 @@ textarea {
   height: 100%;
   width:100%;
   position: absolute;
-  z-index: -1;
   overflow-y: scroll;
 }
 

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -229,8 +229,6 @@ textarea {
   width:100%;
   height: 100%;
   z-index: -1;
-  position: fixed;
-  overflow-y: scroll;
 }
 
 #iframe_a {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -166,6 +166,7 @@ textarea {
   border-bottom: 8px solid #F6F7F9;
 }
 
+/*
 .modal {
   display: none;
   position: fixed;
@@ -175,7 +176,7 @@ textarea {
   top: 0;
   width: 100%;
   height: 100%;
-  overflow: auto;
+  overflow: scroll;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.4);
 }
@@ -196,6 +197,18 @@ textarea {
   animation-duration: 0.4s
 }
 
+.modal-header {
+  padding: 2px 16px;
+  background-color: #565051;
+  color: white;
+}
+
+.modal-body {
+  padding: 2px 16px;
+  color: black
+}
+*/
+
 .close {
   color: white;
   float: right;
@@ -208,17 +221,6 @@ textarea {
   color: #000;
   text-decoration: none;
   cursor: pointer;
-}
-
-.modal-header {
-  padding: 2px 16px;
-  background-color: #565051;
-  color: white;
-}
-
-.modal-body {
-  padding: 2px 16px;
-  color: black
 }
 
 #div_iframe {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -167,7 +167,7 @@ textarea {
 }
 
 .login-modal {
-  display: block;
+  display: none;
   position: fixed;
   z-index: 1;
   padding-top: 100px;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -164,6 +164,7 @@ textarea {
   padding: 0;
   font-size: 12px;
   border: 1px solid #888;
+  min-width: 280px;
   width: 25%;
   overflow: auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -225,6 +225,7 @@ textarea {
   width:100%;
   height:auto;
   z-index: -1;
+  position: relative;
 }
 
 #iframe_a {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -166,7 +166,7 @@ textarea {
   border-bottom: 8px solid #F6F7F9;
 }
 
-.login-modal {
+.modal-login {
   display: none;
   position: fixed;
   z-index: 1;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -232,7 +232,7 @@ textarea {
 #div_iframe {
   padding-top: 1vw;
   width:100%;
-  height: 100%;
+  height: calc(100% - 1vw);
   z-index: -1;
 }
 

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -63,7 +63,7 @@ nav ul li a {
   display: block;
   color: rgba(255, 255, 255, .9);
   text-decoration: none;
-  font-size: 1.5rem;
+  font-size: 2vw;
   border-top: 2px solid transparent;
   border-bottom: 2px solid transparent;
 }
@@ -221,15 +221,17 @@ textarea {
 }
 
 #menu {
-
+  position: fixed;
+  width: 100%;
 }
 
 #login {
 }
 
 #div_iframe {
+  padding-top: 65px;
   width:100%;
-  max-height: 89.7%;
+  max-height: 100%;
   z-index: -1;
 }
 

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -229,7 +229,6 @@ textarea {
 #login {}
 
 #div_iframe {
-  margin-top: 4vw;
   width:100%;
   height: calc(100% - 4vw);
   z-index: -1;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -185,6 +185,7 @@ textarea {
 .dropdown {
   display: none;
   position: absolute;
+  margin-top: 3px;
   background: linear-gradient(to bottom right, white, #F8F8F8) !important;
   box-shadow: 0 4px 10px #565051;
 }
@@ -222,13 +223,13 @@ textarea {
 #menu {
   position: fixed;
   width: 100%;
+  z-index: 10;
 }
 
-#login {
-}
+#login {}
 
 #div_iframe {
-  padding-top: 1vw;
+  padding-top: 4vw;
   width:100%;
   height: calc(100% - 1vw);
   z-index: -1;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -180,22 +180,7 @@ textarea {
   background-color: rgba(0, 0, 0, 0.4);
 }
 
-/*
-.modal {
-  display: none;
-  position: fixed;
-  z-index: 1;
-  padding-top: 100px;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: scroll;
-  background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, 0.4);
-}
-
-.modal-content {
+.modal-login-content {
   position: relative;
   background-color: #fefefe;
   margin: auto;
@@ -211,17 +196,16 @@ textarea {
   animation-duration: 0.4s
 }
 
-.modal-header {
+.modal-login-header {
   padding: 2px 16px;
   background-color: #565051;
   color: white;
 }
 
-.modal-body {
+.modal-login-body {
   padding: 2px 16px;
   color: black
 }
-*/
 
 .close {
   color: white;

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -223,9 +223,10 @@ textarea {
 
 #div_iframe {
   width:100%;
-  height:auto;
+  height: 100%;
   z-index: -1;
-  position: relative;
+  position: fixed;
+  overflow-y: scroll;
 }
 
 #iframe_a {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -28,6 +28,14 @@ h1 {
   text-align: center;
 }
 
+label {
+  font-size: 18px;
+}
+
+input {
+  font-size: 18px;
+}
+
 nav {
   margin: 0 auto;
   max-width: 100%;
@@ -45,14 +53,6 @@ nav ul {
   padding: 0;
   margin: 0;
   list-style: none;
-}
-
-label {
-  font-size: 18px;
-}
-
-input {
-  font-size: 18px;
 }
 
 nav ul li {
@@ -143,29 +143,6 @@ textarea {
   }
 }
 
-.dropdown {
-  display: none;
-  position: absolute;
-  background: linear-gradient(to bottom right, white, #F8F8F8) !important;
-  box-shadow: 0 4px 10px #565051;
-}
-
-.dropdown::after {
-  content: '';
-  position: absolute;
-  left: 30px;
-  top: -8px;
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-bottom: 8px solid white;
-}
-
-.dropdown:hover::after {
-  border-bottom: 8px solid #F6F7F9;
-}
-
 .modal-login {
   display: none;
   position: fixed;
@@ -187,7 +164,7 @@ textarea {
   padding: 0;
   font-size: 12px;
   border: 1px solid #888;
-  width: 60%;
+  width: 25%;
   overflow: auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   -webkit-animation-name: animatetop;
@@ -205,6 +182,29 @@ textarea {
 .modal-login-body {
   padding: 2px 16px;
   color: black
+}
+
+.dropdown {
+  display: none;
+  position: absolute;
+  background: linear-gradient(to bottom right, white, #F8F8F8) !important;
+  box-shadow: 0 4px 10px #565051;
+}
+
+.dropdown::after {
+  content: '';
+  position: absolute;
+  left: 30px;
+  top: -8px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid white;
+}
+
+.dropdown:hover::after {
+  border-bottom: 8px solid #F6F7F9;
 }
 
 .close {

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -229,7 +229,7 @@ textarea {
 
 #div_iframe {
   width:100%;
-  height: 100%;
+  max-height: 89.7%;
   z-index: -1;
 }
 

--- a/web/clear-functions.html
+++ b/web/clear-functions.html
@@ -17,7 +17,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Cleaning stale functions</h2>

--- a/web/container-layout.html
+++ b/web/container-layout.html
@@ -13,7 +13,7 @@
 		function exec() {
 			var div = document.getElementById('modal-body2');
 
-			(div) ? div.innerHTML = div.innerHTML + '<br><p align=center><img heigth="200" width="200" src="/assets/images/searching.jpg"><br><font size=+3><label>Searching for containers</label></font>' : false;
+			(div) ? div.innerHTML = div.innerHTML + '<p align=center><img heigth="200" width="200" src="/assets/images/searching.jpg"><br><font size=+3><label>Searching for containers</label></font>' : false;
 
 			$.get("/nodes?token=" + parent.token, function(data) {
 				var check_data = data;
@@ -24,7 +24,7 @@
 					if (div) {
 						var dist = check_data.data[i].os_type || '';
 						dist = dist.toLowerCase();
-						div.innerHTML = div.innerHTML + '><p align=left>' + distLogo(dist) + '<br>'+ '<font size="+2"><b><br>' + check_data.data[i].hostname + '</b></font><br>';
+						div.innerHTML = div.innerHTML + '<p align=left>' + distLogo(dist) + '<br>'+ '<font size="+2"><b><br>' + check_data.data[i].hostname + '</b></font><br>';
 						var array = check_data.data[i].running_containers;
 						for (var j in array) {
 							if (array[j]) {

--- a/web/container-layout.html
+++ b/web/container-layout.html
@@ -24,7 +24,7 @@
 					if (div) {
 						var dist = check_data.data[i].os_type || '';
 						dist = dist.toLowerCase();
-						div.innerHTML = div.innerHTML + '<br><br><p align=left>' + distLogo(dist) + '<br>'+ '<font size="+2"><b><br>' + check_data.data[i].hostname + '</b></font><br><br>';
+						div.innerHTML = div.innerHTML + '><p align=left>' + distLogo(dist) + '<br>'+ '<font size="+2"><b><br>' + check_data.data[i].hostname + '</b></font><br>';
 						var array = check_data.data[i].running_containers;
 						for (var j in array) {
 							if (array[j]) {
@@ -50,7 +50,6 @@
 				<h2>PiCluster Containers</h2>
 			</div>
 			<div id="modal-body2" class="modal-body">
-				<p align=center></p>
 			</div>
 		</div>
 	</div>

--- a/web/container-layout.html
+++ b/web/container-layout.html
@@ -44,7 +44,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Containers</h2>

--- a/web/current-functions.html
+++ b/web/current-functions.html
@@ -36,7 +36,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Functions Awaiting Data Retrieval</h2>

--- a/web/docs.html
+++ b/web/docs.html
@@ -8,7 +8,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Documentation</h2>
@@ -22,7 +22,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/editconfig.html
+++ b/web/editconfig.html
@@ -36,9 +36,8 @@
 
 			<div class="modal-body">
 				<div id="config_editor" title="PiCluster Configuration Editor">
-					<br>
 					<textarea rows="20" cols="75" id="payload" name="payload" value="" enctype="application/json"></textarea>
-					<br><br>
+					<br>
 					<button id="submit_button">Submit</button>
 				</div>
 			</div>

--- a/web/editconfig.html
+++ b/web/editconfig.html
@@ -35,19 +35,12 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=center>
-					<div id="start" title="PiCluster Configuration Editor">
-						<p align=center>
-							<table style="width:10%">
-								<tr>
-									<td>
-										<br><textarea rows="20" cols="75" id="payload" name="payload" value="" enctype="application/json"></textarea><br><br>
-										<button id="submit_button">Submit</button>
-									</td>
-								</tr>
-							</table>
-						</p>
-					</div>
+				<div id="config_editor" title="PiCluster Configuration Editor">
+					<br>
+					<textarea rows="20" cols="75" id="payload" name="payload" value="" enctype="application/json"></textarea>
+					<br><br>
+					<button id="submit_button">Submit</button>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/web/editconfig.html
+++ b/web/editconfig.html
@@ -28,7 +28,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Configuraton Editor</h2>

--- a/web/exec.html
+++ b/web/exec.html
@@ -34,12 +34,12 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Run Commands on the Cluster</h2>
 			</div>
-			
+
 			<div class="modal-body">
 				<p align=left>
 					<label id="windowfont" for="node_list"><b>Select a Node</b></label>

--- a/web/exec.html
+++ b/web/exec.html
@@ -34,7 +34,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Run Commands on the Cluster</h2>
@@ -92,7 +92,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Terminal</h2>

--- a/web/functions-create.html
+++ b/web/functions-create.html
@@ -26,7 +26,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Create a function</h2>
@@ -64,7 +64,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/functions-viewer.html
+++ b/web/functions-viewer.html
@@ -64,39 +64,27 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=left>
-					<fieldset name="functions" id="functions">
-						<legend>Select a Function</legend>
-						<table style="width:100%">
-							<tr>
-								<select name="function_list" id="function_list">
-							</select>
-							</tr>
-							<tr>
-								&nbsp;
-							</tr>
-							<tr>
-								<button id="submit_button">View</button>
-							</tr>
-						</table>
-					</fieldset>
-					<fieldset name="options" id="options">
-						<legend>Function Data</legend>
-						</select>
-						<label>Data Retrieval</label>
-						<input type="text" size="80" id="url" name="url" value=""></font>
-						<br><br>
-						<label><i>If you execute the above command on your computer, you will not be able to see the output</i></label>
-						<br>
-						<label><i>here anymore because the function will be removed.</i></label>
-						<br>
-						<br>
-						<legend>Function Data</legend>
-						<textarea id="textarea" rows="15" cols="74">
-						</textarea>
-					</fieldset>
-					<p align=center></p>
-				</p>
+				<fieldset name="functions" id="functions">
+					<legend>Select a Function</legend>
+					<div>
+						<select name="function_list" id="function_list"></select>
+					</div>
+					<div>
+						<button id="submit_button">View</button>
+					</div>
+				</fieldset>
+				<fieldset name="options" id="options">
+					<legend>Function Data</legend>
+					<label>Data Retrieval</label>
+					<input type="text" id="url" name="url" value="">
+					<br>
+					<label><i>If you execute the above command on your computer, you will not be able to see the output</i></label>
+					<br>
+					<label><i>here anymore because the function will be removed.</i></label>
+					<br>
+					<legend>Function Data</legend>
+					<textarea id="function_output" rows="15"></textarea>
+				</fieldset>
 			</div>
 		</div>
 	</div>

--- a/web/functions-viewer.html
+++ b/web/functions-viewer.html
@@ -57,7 +57,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>View Functions</h2>
@@ -102,7 +102,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/hb.html
+++ b/web/hb.html
@@ -17,7 +17,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Running a heartbeat check on all containers</h2>

--- a/web/hb.html
+++ b/web/hb.html
@@ -17,7 +17,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Running a heartbeat check on all containers</h2>
@@ -44,7 +44,7 @@
 		}
 
 		output_modal.style.display = "block";
-		
+
 		exec();
 	</script>
 </html>

--- a/web/image-layout.html
+++ b/web/image-layout.html
@@ -40,7 +40,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Images</h2>

--- a/web/image-layout.html
+++ b/web/image-layout.html
@@ -40,14 +40,13 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Images</h2>
 			</div>
 
 			<div id="modal-body2" class="modal-body">
-				<p align=center></p>
 			</div>
 		</div>
 	</div>

--- a/web/killvip.html
+++ b/web/killvip.html
@@ -17,7 +17,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Resetting VIP on all hosts</h2>

--- a/web/killvip.html
+++ b/web/killvip.html
@@ -17,12 +17,12 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Resetting VIP on all hosts</h2>
 			</div>
-			
+
 			<div id="modal-body2" class="modal-body">
 				<p align=center>
 					Please wait......

--- a/web/log.html
+++ b/web/log.html
@@ -17,7 +17,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Log</h2>

--- a/web/log.html
+++ b/web/log.html
@@ -24,15 +24,7 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=center>
-					<table style="width:10%">
-						<tr>
-							<td>
-								<textarea rows="20" cols="80" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
-							</td>
-						</tr>
-					</table>
-				</p>
+				<textarea rows="20" cols="80" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
 			</div>
 		</div>
 	</div>

--- a/web/main.html
+++ b/web/main.html
@@ -169,13 +169,13 @@
 
 <body>
 	<div id="login" class="modal-login">
-		<div class="modal-content">
-			<div class="modal-header">
+		<div class="modal-login-content">
+			<div class="modal-login-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster 2.2 Login</h2>
 			</div>
 
-			<div class="modal-body">
+			<div class="modal-login-body">
 				<p align=center>
 					<img src="/assets/images/logo.png" height="250" width="200">
 					<br><label>Please login to continue<label>

--- a/web/main.html
+++ b/web/main.html
@@ -265,7 +265,7 @@
 			login();
 		}
 
-		/*modal.style.display = "block";*/
+		modal.style.display = "block";
 
 		$("html").click(function() {
 			$(".dropdown").hide();

--- a/web/main.html
+++ b/web/main.html
@@ -168,7 +168,7 @@
 </head>
 
 <body>
-	<div id="login" class="modal">
+	<div id="login">
 		<div class="modal-content">
 			<div class="modal-header">
 				<span class="close">&times;</span>
@@ -265,7 +265,7 @@
 			login();
 		}
 
-		modal.style.display = "block";
+		/*modal.style.display = "block";*/
 
 		$("html").click(function() {
 			$(".dropdown").hide();

--- a/web/main.html
+++ b/web/main.html
@@ -168,7 +168,7 @@
 </head>
 
 <body>
-	<div id="login">
+	<div id="login" class="modal-login">
 		<div class="modal-content">
 			<div class="modal-header">
 				<span class="close">&times;</span>

--- a/web/manage-images.html
+++ b/web/manage-images.html
@@ -41,7 +41,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Manage Images</h2>

--- a/web/manage-images.html
+++ b/web/manage-images.html
@@ -41,7 +41,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Manage Images</h2>
@@ -84,7 +84,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/manage.html
+++ b/web/manage.html
@@ -9,7 +9,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Manage Containers</h2>
@@ -64,7 +64,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/manage.html
+++ b/web/manage.html
@@ -9,7 +9,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Manage Containers</h2>
@@ -25,7 +25,7 @@
 					</fieldset>
 					<fieldset name="options" id="options">
 						<legend>Options</legend>
-						<label for="radio-start">Start</label>
+						<label for="radio_start">Start</label>
 						<input type="radio" name="radio_start" id="radio_start">
 						<br>
 						<label for="radio_stop">Stop</label>

--- a/web/nodes.html
+++ b/web/nodes.html
@@ -127,7 +127,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Nodes</h2>

--- a/web/prune.html
+++ b/web/prune.html
@@ -17,7 +17,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Cleaning stale Docker containers</h2>
@@ -40,7 +40,7 @@
 		}
 
 		output_modal.style.display = "block";
-		
+
 		exec();
 	</script>
 </html>

--- a/web/prune.html
+++ b/web/prune.html
@@ -17,7 +17,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Cleaning stale Docker containers</h2>

--- a/web/pullimages.html
+++ b/web/pullimages.html
@@ -55,7 +55,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Pull Images</h2>
@@ -234,7 +234,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/reloadconfig.html
+++ b/web/reloadconfig.html
@@ -18,7 +18,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Reloading Configuration File</h2>

--- a/web/reloadconfig.html
+++ b/web/reloadconfig.html
@@ -18,7 +18,7 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Reloading Configuration File</h2>

--- a/web/rmhost.html
+++ b/web/rmhost.html
@@ -24,7 +24,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Remove a host from PiCluster</h2>
@@ -56,7 +56,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/rmhost.html
+++ b/web/rmhost.html
@@ -24,7 +24,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Remove a host from PiCluster</h2>

--- a/web/rsyslog.html
+++ b/web/rsyslog.html
@@ -42,47 +42,40 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
-			<div class="modal-header">
-				<span class="close">&times;</span>
-				<h2>PiCluster Rsyslog Viewer</h2>
-			</div>
+		<div class="modal-body">
+			<div class="modal-content modal-medium">
+				<div class="modal-header">
+					<span class="close">&times;</span>
+					<h2>PiCluster Rsyslog Viewer</h2>
+				</div>
 
-			<div class="modal-body">
-				<div class="modal-content modal-medium">
-					<div class="modal-header">
-						<span class="close">&times;</span>
-						<h2>PiCluster Syslog Viewer</h2>
+				<div class="modal-body">
+					<div id="log_search">
+						<div id="log_search_bar">
+							<input id="query" type="text" rows="30" cols="60" name="query" name="query">
+						</div>
+						<div id="log_search_button">
+							<button id="submit_button">Search</button>
+						</div>
 					</div>
 
-					<div class="modal-body">
-						<div id="log_search">
-							<div id="log_search_bar">
-								<input id="query" type="text" rows="30" cols="60" name="query" name="query">
-							</div>
-							<div id="log_search_button">
-								<button id="submit_button">Search</button>
-							</div>
+					<div id="log_type">
+						<div id="log_type_error" class="log_type_box">
+							<label><input type="checkbox" id="error" onchange="search('error','error')" value="error">Errors</label><br>
 						</div>
+						<div id="log_type_failure" class="log_type_box">
+							<label><input type="checkbox" id="failure" onchange="search('failure','failure')" value="failure">Failures</label><br>
+						</div>
+						<div id="log_type_warning" class="log_type_box">
+							<label><input type="checkbox" id="warning" onchange="search('warning','warning')" value="warning">Warnings</label><br>
+						</div>
+						<div id="log_type_today" class="log_type_box">
+							<label><input type="checkbox" id="today" onchange="search('today','today')" value="today">Today</label><br>
+						</div>
+					</div>
 
-						<div id="log_type">
-							<div id="log_type_error" class="log_type_box">
-								<label><input type="checkbox" id="error" onchange="search('error','error')" value="error">Errors</label><br>
-							</div>
-							<div id="log_type_failure" class="log_type_box">
-								<label><input type="checkbox" id="failure" onchange="search('failure','failure')" value="failure">Failures</label><br>
-							</div>
-							<div id="log_type_warning" class="log_type_box">
-								<label><input type="checkbox" id="warning" onchange="search('warning','warning')" value="warning">Warnings</label><br>
-							</div>
-							<div id="log_type_today" class="log_type_box">
-								<label><input type="checkbox" id="today" onchange="search('today','today')" value="today">Today</label><br>
-							</div>
-						</div>
-
-						<div id="log_output">
-							<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
-						</div>
+					<div id="log_output">
+						<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
 					</div>
 				</div>
 			</div>

--- a/web/rsyslog.html
+++ b/web/rsyslog.html
@@ -42,7 +42,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Rsyslog Viewer</h2>

--- a/web/rsyslog.html
+++ b/web/rsyslog.html
@@ -49,42 +49,42 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=center>
-					<table id="log_search">
-						<tr>
-							<td>
-								<input type="text" rows="30" cols="60" id="query" name="query" name="query"><br>
-							</td>
-							<td>
+				<div class="modal-content modal-medium">
+					<div class="modal-header">
+						<span class="close">&times;</span>
+						<h2>PiCluster Syslog Viewer</h2>
+					</div>
+
+					<div class="modal-body">
+						<div id="log_search">
+							<div id="log_search_bar">
+								<input id="query" type="text" rows="30" cols="60" name="query" name="query">
+							</div>
+							<div id="log_search_button">
 								<button id="submit_button">Search</button>
-							</td>
-						</tr>
-					</table>
+							</div>
+						</div>
 
-					<table id="log_type">
-						<tr>
-							<td>
+						<div id="log_type">
+							<div id="log_type_error" class="log_type_box">
 								<label><input type="checkbox" id="error" onchange="search('error','error')" value="error">Errors</label><br>
-							</td>
-							<td>
+							</div>
+							<div id="log_type_failure" class="log_type_box">
 								<label><input type="checkbox" id="failure" onchange="search('failure','failure')" value="failure">Failures</label><br>
-							</td>
-							<td>
+							</div>
+							<div id="log_type_warning" class="log_type_box">
 								<label><input type="checkbox" id="warning" onchange="search('warning','warning')" value="warning">Warnings</label><br>
-							</td>
-							<td>
+							</div>
+							<div id="log_type_today" class="log_type_box">
 								<label><input type="checkbox" id="today" onchange="search('today','today')" value="today">Today</label><br>
-							</td>
-						</tr>
-					</table>
+							</div>
+						</div>
 
-					<table id="log_output">
-						<tr>
-							<td>
-								<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
-							</td>
-						</tr>
-					</table>
+						<div id="log_output">
+							<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
+						</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/web/syslog.html
+++ b/web/syslog.html
@@ -50,42 +50,33 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=center>
-					<table id="log_search">
-						<tr>
-							<td>
-								<input type="text" rows="30" cols="60" id="query" name="query" name="query"><br>
-							</td>
-							<td>
-								<button id="submit_button">Search</button>
-							</td>
-						</tr>
-					</table>
+				<div id="log_search">
+					<div id="log_search_bar">
+						<input id="query" type="text" rows="30" cols="60" name="query" name="query">
+					</div>
+					<div id="log_search_button">
+						<button id="submit_button">Search</button>
+					</div>
+				</div>
 
-					<table id="log_type">
-						<tr>
-							<td>
-								<label><input type="checkbox" id="error" onchange="search('error','error')" value="error">Errors</label><br>
-							</td>
-							<td>
-								<label><input type="checkbox" id="failure" onchange="search('failure','failure')" value="failure">Failures</label><br>
-							</td>
-							<td>
-								<label><input type="checkbox" id="warning" onchange="search('warning','warning')" value="warning">Warnings</label><br>
-							</td>
-							<td>
-								<label><input type="checkbox" id="today" onchange="search('today','today')" value="today">Today</label><br>
-							</td>
-						</tr>
-					</table>
+				<div id="log_type">
+					<div id="log_type_error" class="log_type_box">
+						<label><input type="checkbox" id="error" onchange="search('error','error')" value="error">Errors</label><br>
+					</div>
+					<div id="log_type_failure" class="log_type_box">
+						<label><input type="checkbox" id="failure" onchange="search('failure','failure')" value="failure">Failures</label><br>
+					</div>
+					<div id="log_type_warning" class="log_type_box">
+						<label><input type="checkbox" id="warning" onchange="search('warning','warning')" value="warning">Warnings</label><br>
+					</div>
+					<div id="log_type_today" class="log_type_box">
+						<label><input type="checkbox" id="today" onchange="search('today','today')" value="today">Today</label><br>
+					</div>
+				</div>
 
-					<table id="log_output">
-						<tr>
-							<td>
-								<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
-							</td>
-						</tr>
-					</table>
+				<div id="log_output">
+					<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/web/syslog.html
+++ b/web/syslog.html
@@ -43,7 +43,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Syslog Viewer</h2>

--- a/web/terminal.html
+++ b/web/terminal.html
@@ -48,7 +48,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Terminal</h2>
@@ -79,7 +79,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div id="terminal_modal" class="modal-content">
+		<div id="terminal_modal" class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Terminal</h2>

--- a/web/upload.html
+++ b/web/upload.html
@@ -9,7 +9,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Upload Dockerfile Archive</h2>
@@ -34,7 +34,7 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content">
+		<div class="modal-content modal-medium">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>

--- a/web/upload.html
+++ b/web/upload.html
@@ -9,7 +9,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Upload Dockerfile Archive</h2>


### PR DESCRIPTION
This PR contains fixes for the modal overflow cutoff in issue #94, along with **minor** modal CSS issues.

Also included in this are:
* Scaling nav menu to fit better on mobile devices
* Modals split into small and medium size by using the modal-small and modal-medium CSS classes
* Removal of unneeded tables in favor of using div elements
* Single scroll bar (no more scrollbar for inner modal boxes)
* More cohesive UI experience with nav menu fit optimally over dynamically fit iframe element