### PR TITLE
Unstretch icons on web/blank.html

### DIFF
--- a/web/blank.html
+++ b/web/blank.html
@@ -34,36 +34,36 @@
 		<br>
 		<img heigth="75" width="300" src="/assets/images/logo.png">
 		<br>
-		<b>Welcome to PiCluster!
+		<b>Welcome to PiCluster!</b>
 	</p>
-
-	<p align=center>
-		<table style="width:20%">
-			<tr>
-				<td>
-					<a href='https://github.com/picluster/picluster' style="text-decoration:none" target="_blank"> <img height="75" width="100" src="/assets/images/GitHub-Mark-120px-plus.png"><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;GitHub</a>
-				</td>
-				<td>
-					<a href='https://github.com/picluster/picluster/issues' style="text-decoration:none" target="_blank"> <img height="75" width="100" src="/assets/images/Debug-Bug-icon.png"><br>&nbsp;&nbsp;&nbsp;Report Issue</a>
-				</td>
-				<td>
-					<div class="page">
-						<div class="clearfix">
-							<div id="running-class" class="c100 p0 small">
-								<span id='running_containers'>0%</span>
-								<div class="slice">
-									<div class="bar"></div>
-									<div class="fill"></div>
-								</div>
-							</div>
-							<font size="3"><a style="text-decoration:none" href="/container-layout.html"> &nbsp;&nbsp;Running</a></font>
-						</div>
-					</div>
-				</td>
-			</tr>
-		</table>
-		<script>
-			getContainerStatus();
-		</script>
+  <div style="text-align: center;">
+    <a href='#' style="display: inline-block; text-align: center; width: 100px !important; height: 100px; text-decoration:none" target="_blank">
+      <img style="height: 75px; width: auto; vertical-align: top;" src="/assets/images/GitHub-Mark-120px-plus.png">
+      <br>
+      GitHub
+    </a>
+    <a href='#' style="display: inline-block; text-align: center; width: 100px; height: 100px; text-decoration:none" target="_blank">
+      <img style="height: 75px; width: auto; vertical-align: top;" src="/assets/images/Debug-Bug-icon.png">
+      <br>
+      Report Issue
+    </a>
+    <a style="text-decoration:none; display: inline-block; text-align: center; width: 100px; height: 100px; vertical-align: top;" href="container-layout.html">
+      <div class="page" style="height: 75px; width: 75px; margin: 0 auto; display: block;">
+        <div class="clearfix">
+          <div id="running-class" class="c100 p0 small" style="float: none; margin: 0 auto; cursor: pointer;">
+            <span id='running_containers'>0%</span>
+            <div class="slice">
+              <div class="bar"></div>
+              <div class="fill"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      Running
+    </a>
+  </div>
+  <script>
+    getContainerStatus();
+  </script>
 </body>
 </html>

--- a/web/blank.html
+++ b/web/blank.html
@@ -37,12 +37,12 @@
 		<b>Welcome to PiCluster!</b>
 	</p>
   <div style="text-align: center;">
-    <a href='#' style="display: inline-block; text-align: center; width: 100px !important; height: 100px; text-decoration:none" target="_blank">
+    <a href='https://github.com/picluster/picluster' style="display: inline-block; text-align: center; width: 100px !important; height: 100px; text-decoration:none" target="_blank">
       <img style="height: 75px; width: auto; vertical-align: top;" src="/assets/images/GitHub-Mark-120px-plus.png">
       <br>
       GitHub
     </a>
-    <a href='#' style="display: inline-block; text-align: center; width: 100px; height: 100px; text-decoration:none" target="_blank">
+    <a href='https://github.com/picluster/picluster/issues' style="display: inline-block; text-align: center; width: 100px; height: 100px; text-decoration:none" target="_blank">
       <img style="height: 75px; width: auto; vertical-align: top;" src="/assets/images/Debug-Bug-icon.png">
       <br>
       Report Issue


### PR DESCRIPTION
Accidentally removed the links from the icons, but just added them back.  The table is removed, a lonely b tag gained a partner and the icons are unstretched.  The circle graph is ever so slightly off center from the border... I'll have to investigate to figure out what can be done about that.  I won't add anything to the external CSS file until @TokinRing gets Issue #94 figured out.  Please make sure everything works in this pull request, especially the circle graph, as I haven't been able to test that out.  It should in theory work, but I don't know for sure.