### PR TITLE
more consistent file naming, major UI bug fixes, more consistent UI

### DIFF
--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -1,5 +1,4 @@
 html {
-  height: 100%;
 }
 
 body {
@@ -59,6 +58,11 @@ table tbody tr td label {
   color: black;
 }
 
+fieldset {
+  margin-top: 5px;
+  margin-bottom: 15px;
+}
+
 @-webkit-keyframes animatetop {
   from {
     top: -300px;
@@ -83,15 +87,18 @@ table tbody tr td label {
 
 .modal {
   display: none;
-  position: relative;
   z-index: 1;
-  padding-top: 5vw;
-  left: 0;
-  top: 0;
-  height: 100%;
+  padding-top: 5px;
+  height: 99%;
   width: 100%;
   background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.4);3
+}
+
+.modal-description {
+  text-align: center;
+  font-size: 18px;
+  margin: 10px;
 }
 
 .modal-content {
@@ -113,11 +120,11 @@ table tbody tr td label {
   min-width: 370px
 }
 
-.modal-medium {
+.modal-large {
   width: 75%;
   min-width: 600px;
-  min-height: 75%;
-  margin-bottom: 20px;
+  height: 95%;
+  overflow-y: scroll;
 }
 
 .modal-header {
@@ -127,8 +134,13 @@ table tbody tr td label {
 }
 
 .modal-body {
-  padding: 1px 10px;
+  padding: 1px 10px 10px;
   color: black;
+  font-size: 18px;
+}
+
+.modal_input {
+  margin-bottom: 10px;
 }
 
 .close {
@@ -200,6 +212,21 @@ table tbody tr td label {
   text-align: center;
 }
 
+.page {
+  display: block;
+  height: 75px;
+  margin: 0 auto;
+  width: 75px;
+}
+
+#modal_container {
+  height: 99%;
+}
+
+#submit_button {
+  display: inline;
+}
+
 #log_search {
   width: 100%;
   text-align: center;
@@ -230,6 +257,9 @@ table tbody tr td label {
 
 #log_output {
   width: 100%;
+  height: 79%;
+  padding: 0;
+  margin: 0;
 }
 
 #upload-widget {
@@ -253,9 +283,6 @@ table tbody tr td label {
 
 #terminal {
   width: 100%;
-  position: relative;
-  left: -1.04em;
-  top: -0.3em;
 }
 
 #terminal .prompt {
@@ -264,33 +291,74 @@ table tbody tr td label {
 
 #host {
   font-size: 18px;
+  width: 50%;
+  display: inline;
+  margin-right: 5px;
+}
+
+#host_add {
+  text-align: center;
 }
 
 #container_list {
   font-size: 16px;
 }
 
+#container_list_fieldset {}
+#container_list_options_fieldset {}
+#container-add-fieldset {}
+#container-heartbeat-fieldset {}
+
 #container {
   font-size: 16px;
+}
+
+#functions {
+  margin-top: 5px;
+  margin-bottom: 10px;
 }
 
 #function_list {
   font-size: 18px;
 }
 
+#function_list_selector {
+  width: 150px;
+  margin-right: 20px;
+  display: inline;
+}
+
+#function_list_submit {
+  width: 100px;
+  display: inline;
+}
+
 #function_output {
   width: 100%;
+  height: 50%;
 }
 
 #function_url {}
 
 #node_list {
   font-size: 18px;
+  margin-right: 5px;
+}
+
+#node_list_remove {
+  text-align: center;
+}
+
+#node_failover_constraint {
+  margin-bottom: 10px;
 }
 
 #image_list {
   font-size: 18px;
 }
+
+#image_list_fieldset {}
+#image_list_options_fieldset {}
 
 #command_entry {
   font-size: 18px;
@@ -298,33 +366,36 @@ table tbody tr td label {
 
 #command_output {
   width: 100%;
+  min-height: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+#exec_output {
+  width: 100%;
+  min-height: 80%;
+  padding: 0;
+  margin: 0;
 }
 
 #windowfont {
   font-size: 18px;
 }
 
-#modal-body2 {
-  font-size: 18px;
+#config_editor {
+  width: 100%;
+  height: 80%;
 }
-
-#config_editor {}
 
 #payload {
   width: 100%;
+  height: 100%;
 }
 
 #node_status_logo {
   font-size: 72px;
   max-width: 72px;
   text-align: center;
-}
-
-.page {
-  display: block;
-  height: 75px;
-  margin: 0 auto;
-  width: 75px;
 }
 
 #source,
@@ -363,3 +434,22 @@ table tbody tr td label {
 #rerun_div {
   text-align: center;
 }
+
+#config-reload-modal-body {}
+#containers-add-modal-body {}
+#containers-layout-modal-body {}
+#containers-manage-modal-body {}
+#docs-modal-body {}
+#functions-clear-modal-body {}
+#functions-create-modal-body {}
+#functions-current-modal-body {}
+#functions-viewer-modal-body {}
+#heartbeat-modal-body {}
+#images-manage-modal-body {}
+#images-prune-modal-body {}
+#images-pull-modal-body {}
+#images-upload-modal-body {}
+#killvip-modal-body {}
+#nodes-add-modal-body {}
+#nodes-list-modal-body {}
+#nodes-removed-modal-body {}

--- a/web/assets/picluster-ui.css
+++ b/web/assets/picluster-ui.css
@@ -188,6 +188,7 @@ textarea {
   margin-top: 3px;
   background: linear-gradient(to bottom right, white, #F8F8F8) !important;
   box-shadow: 0 4px 10px #565051;
+  overflow-y: scroll;
 }
 
 .dropdown::after {
@@ -230,6 +231,7 @@ textarea {
 
 #div_iframe {
   width:100%;
+  padding-top: 4.3vw;
   height: calc(100% - 4vw);
   z-index: -1;
 }
@@ -239,7 +241,6 @@ textarea {
   border-width: 0px;
   height: 100%;
   width:100%;
-  position: absolute;
   overflow-y: scroll;
 }
 

--- a/web/blank.html
+++ b/web/blank.html
@@ -47,7 +47,7 @@
       <br>
       Report Issue
     </a>
-    <a href="container-layout.html" id="status_circle">
+    <a href="containers-layout.html" id="status_circle">
       <div class="page">
         <div class="clearfix">
           <div id="running-class" class="c100 p0 small">

--- a/web/config-edit.html
+++ b/web/config-edit.html
@@ -28,7 +28,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Configuraton Editor</h2>
@@ -36,9 +36,11 @@
 
 			<div class="modal-body">
 				<div id="config_editor" title="PiCluster Configuration Editor">
-					<textarea rows="20" cols="75" id="payload" name="payload" value="" enctype="application/json"></textarea>
-					<br>
-					<button id="submit_button">Submit</button>
+					<textarea id="payload" name="payload" value="" enctype="application/json"></textarea>
+					
+					<p align=center>
+						<button id="submit_button">Submit</button>
+					</p>
 				</div>
 			</div>
 		</div>
@@ -60,8 +62,6 @@
 		modal.style.display = "block";
 
 		getconfig();
-
-		parent.resize_iframe_height();
 	</script>
 </body>
 </html>

--- a/web/config-reload.html
+++ b/web/config-reload.html
@@ -9,7 +9,7 @@
 		function exec() {
 			$.get("/reloadconfig?token=" + parent.token, function(data) {
 				var output = data.replace(/(?:\r\n|\r|\n)/g, '<br />');
-				var div = document.getElementById('modal-body2');
+				var div = document.getElementById('config-reload-modal-body');
 				div.innerHTML = data;
 			});
 		}
@@ -24,7 +24,7 @@
 				<h2>Reloading Configuration File</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
+			<div id="config-reload-modal-body" class="modal-body">
 				<p align=center></p>
 			</div>
 		</div>
@@ -41,7 +41,5 @@
 		output_modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/containers-add.html
+++ b/web/containers-add.html
@@ -7,7 +7,7 @@
 	<script>
 		function exec() {
 			var node_list = document.getElementById("node_list");
-			var host_list = document.getElementsByName('host_list');
+			var container-heartbeat-fieldset = document.getElementsByName('container-heartbeat-fieldset');
 			var path = '/addcontainer';
 			var host = node_list.options[node_list.selectedIndex].value;
 			var container = $("#container_name").val();
@@ -15,8 +15,8 @@
 			var heartbeat_args = $("#heartbeat_args").val();
 			var failover_constraints = '';
 
-			host_list.forEach(function(node, i) {
-				failover_constraints += host_list[i].checked ? (failover_constraints ? ',' + node.value : failover_constraints) : node.value;
+			container-heartbeat-fieldset.forEach(function(node, i) {
+				failover_constraints += container-heartbeat-fieldset[i].checked ? (failover_constraints ? ',' + node.value : failover_constraints) : node.value;
 			});
 
 			failover_constraints = !failover_constraints ? 'none' : failover_constraints;
@@ -29,7 +29,7 @@
 				heartbeat_args: heartbeat_args,
 				failover_constraints: container + ',' + failover_constraints
 			}, function(data) {
-				var div = document.getElementById('modal-body2');
+				var div = document.getElementById('containers-add-modal-body');
 				div.innerHTML = '<label id="windowfont"> Sent request to the server. Please check the logs and running containers for updated information.<br><br>\n' + data;
 			});
 		}
@@ -38,48 +38,51 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Add a container to PiCluster</h2>
 			</div>
 			<div class="modal-body">
-				<p align=left>
-					<label id="windowfont">This will add a new container to the PiCluster configuration file.
-					<br><br> Please ensure that the Dockerfiles are already on the node in the correct location.</label>
-					<br><br>
-					<label id="windowfont" for="node_list"><b>Select a Node</b></label>
-					<select name="node_list" id="node_list">
-						</select>
-					<br><br>
-					<b><label id="windowfont">Container Name:</b></label>
-					<input type="text" size="15" id="container_name" name="container_name" value=""></font>
-					<br><br>
-					<b><label id="windowfont">Container Arguments:</label></b>
-					<input type="text" size="25" id="container_args" name="container_args" value=""></font>
-					<br><br>
-					<br><b><label id="windowfont">Heartbeat and Host Failover: (Optional)</label></b>
-					<fieldset name="host_list" id="host_list">
-						<b><label id="windowfont">Heartbeat Port:</label></b>
-						<input type="text" size="5" id="heartbeat_args" name="heartbeat_args" value=""></font>
-						<br><br>
-						<b><label id="windowfont">Host Failover Constraints (Optional):</label></b>
-						<br><br>
-					</fieldset>
-					<p align=center>
-						<button id="submit_button">Submit</button>
-					</p>
+				<div class="modal-description">
+					Add a new container to the PiCluster config file.
+				</div>
+
+				<fieldset id="container-add-fieldset">
+					<legend><b>Container</b></legend>
+					<label class="windowfont">Name</label>
+					<input type="text" size="15" id="container_name" class="modal_input" name="container_name" value=""></font>
+					<br>
+					<label class="windowfont">Arguments</label>
+					<input type="text" size="25" id="container_args" class="modal_input" name="container_args" value=""></font>
+					<br>
+					<label class="windowfont">Deploy on</label>
+					<select name="node_list" id="node_list"></select>
+				</fieldset>
+
+				<fieldset name="container-heartbeat-fieldset" id="container-heartbeat-fieldset">
+					<legend><b>Heartbeat/Node Failover</b> <i>(Optional)</i></legend>
+					<label class="windowfont">Heartbeat Port</label>
+					<input type="text" size="5" id="heartbeat_args" class="modal_input" name="heartbeat_args" value="">
+					<br>
+					<div id="node_failover_constraint">
+						<label class="windowfont">Node Failover Constraints <i>(Optional)</i></label>
+					</div>
+				</fieldset>
+				<p align=center>
+					<button id="submit_button">Submit</button>
+				</p>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
-			<div id="modal-body2" class="modal-body">
+			<div id="containers-add-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
 			</div>
@@ -94,11 +97,11 @@
 			$.get("/nodes?token=" + parent.token, function(data) {
 				for (var i in data.nodes) {
 					option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
-					checkbox += '<label id="windowfont" for="host_list">' + data.nodes[i] + '</label><input type="checkbox" name="host_list" value="' + data.nodes[i] + '" />&nbsp;&nbsp;&nbsp;&nbsp;';
+					checkbox += '<input type="checkbox" name="container-heartbeat-fieldset" class="modal_input" value="' + data.nodes[i] + '" /><label id="windowfont" for="container-heartbeat-fieldset">' + data.nodes[i] + '</label><br>';
 				}
 				option += '<option value="' + '*' + '">' + '*' + '</option>';
 				$('#node_list').append(option);
-				$('#host_list').append(checkbox);
+				$('#container-heartbeat-fieldset').append(checkbox);
 			});
 		});
 
@@ -123,7 +126,5 @@
 		}
 
 		modal_container.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/containers-layout.html
+++ b/web/containers-layout.html
@@ -11,7 +11,7 @@
 		};
 
 		function exec() {
-			var div = document.getElementById('modal-body2');
+			var div = document.getElementById('container-layout-modal-body');
 
 			(div) ? div.innerHTML = div.innerHTML + '<p align=center><img heigth="200" width="200" src="/assets/images/searching.jpg"><br><font size=+3><label>Searching for containers</label></font>' : div;
 
@@ -28,7 +28,7 @@
 						var array = check_data.data[i].running_containers;
 						for (var j in array) {
 							if (array[j]) {
-								div.innerHTML = div.innerHTML + '<font size=+1><a href="/manage.html" style="text-decoration:none" onclick="link_function(\'' + array[j] + '\')">' + array[j] + '</a<</font><br><ol>';
+								div.innerHTML = div.innerHTML + '<font size=+1><a href="/containers-manage.html" style="text-decoration:none" onclick="link_function(\'' + array[j] + '\')">' + array[j] + '</a<</font><br><ol>';
 							}
 						}
 					}
@@ -44,13 +44,13 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Containers</h2>
 			</div>
-			<div id="modal-body2" class="modal-body">
-			</div>
+
+			<div id="container-layout-modal-body" class="modal-body"></div>
 		</div>
 	</div>
 
@@ -65,7 +65,5 @@
 		output_modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/containers-manage.html
+++ b/web/containers-manage.html
@@ -16,60 +16,51 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=left>
-					<fieldset>
-						<label for="container_list">Select a Container</label>
-						<select name="container_list" id="container_list">
-			    </select>
-						<br><br>
-					</fieldset>
-					<fieldset name="options" id="options">
-						<legend>Options</legend>
-						<label for="radio_start">Start</label>
-						<input type="radio" name="radio_start" id="radio_start">
-						<br>
-						<label for="radio_stop">Stop</label>
-						<input type="radio" name="radio_stop" id="radio_stop">
-						<br>
-						<label for="radio_restart">Restart</label>
-						<input type="radio" name="radio_restart" id="radio_restart">
-						<br>
-						<label for="radio_delete">Delete</label>
-						<input type="radio" name="radio_delete" id="radio_delete">
-						<br>
-						<label for="radio_create">Create and Run</label>
-						<input type="radio" name="radio_create" id="radio_create">
-						<br>
-						<label for="radio_container_log">View Logs</label>
-						<input type="radio" name="radio_container_log" id="radio_container_log">
-						<br>
-						<label for="radio_remove_container_config">Remove Config</label>
-						<input type="radio" name="radio_remove_container_config" id="radio_remove_container_config">
-						<br>
-						</select>
-					</fieldset>
-					<fieldset>
-						<label for="radio_change_host">Change Host to</label>
-						<select name="node_list" id="node_list">
-								<input type="radio" name="radio_change_host" id="radio_change_host">
-				    </select>
-						<br><br>
-					</fieldset>
-					<p align=center>
-						<button id="submit_button">Submit</button>
-					</p>
+				<fieldset id="container_list_fieldset">
+					<legend><b>Container</b></legend>
+					<select name="container_list" id="container_list"></select>
+				</fieldset>
+				<fieldset name="options" id="container_list_options_fieldset">
+					<legend><b>Options</b></legend>
+					<input type="radio" name="options_radio" id="radio_start">
+					<label for="radio_start">Start</label>
+					<br>
+					<input type="radio" name="options_radio" id="radio_stop">
+					<label for="radio_stop">Stop</label>
+					<br>
+					<input type="radio" name="options_radio" id="radio_restart">
+					<label for="radio_restart">Restart</label>
+					<br>
+					<input type="radio" name="options_radio" id="radio_delete">
+					<label for="radio_delete">Delete</label>
+					<br>
+					<input type="radio" name="options_radio" id="radio_create">
+					<label for="radio_create">Create and Run</label>
+					<br>
+					<input type="radio" name="options_radio" id="radio_container_log">
+					<label for="radio_container_log">View Logs</label>
+					<br>
+					<input type="radio" name="options_radio" id="radio_remove_container_config">
+					<label for="radio_remove_container_config">Remove Config</label>
+					<br>
+					<input type="radio" name="options_radio" id="radio_change_host">
+					<label for="radio_change_host">Change Node to</label>
+					<select name="node_list" id="node_list"></select>
+				</fieldset>
+				<p align=center>
+					<button id="submit_button">Submit</button>
 				</p>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
-			<div id="modal-body2" class="modal-body">
+			<div id="containers-manage-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
 			</div>
@@ -121,7 +112,7 @@
 						container: container,
 						newhost: node
 					}, function(data) {
-						var div = document.getElementById('modal-body2');
+						var div = document.getElementById('containers-manage-modal-body');
 						div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.<br><br>\n' + data.replace(/(?:\r\n|\r|\n)/g, '<br />');
 					});
 				}
@@ -175,7 +166,5 @@
 		}
 
 		modal.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/docs.html
+++ b/web/docs.html
@@ -6,7 +6,7 @@
 	<link rel="stylesheet" href="/assets/picluster-iframe.css">
   <script>
 	  function display_doc_markdown() {
-			var div = document.getElementById('modal-body2');
+			var div = document.getElementById('docs-modal-body');
 			var docfile = document.doc_id;
 
 
@@ -24,7 +24,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Documentation</h2>
@@ -39,13 +39,13 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
+			<div id="docs-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
 				</p>
@@ -76,7 +76,5 @@
 		});
 
 		display_doc_markdown();
-
-		parent.resize_iframe_height();
 		</script>
 </html>

--- a/web/exec.html
+++ b/web/exec.html
@@ -42,73 +42,75 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=left>
-					<label id="windowfont" for="node_list"><b>Select a Node</b></label>
-					<select name="node_list" id="node_list">
-				    </select>
-					<br><br>
-					<label id="windowfont" for="command_list"><b>Saved Commands</b></label>
-					<select name="command_list" id="command_list">
-					 </select>
-					<br><br>
-					<b><label id="windowfont">Command:<label></b><br><br>
-					<input type="text" size="30" id="command_entry" name="command_entry" value=""></font>
-					<br><br>
+				<fieldset class="">
+					<legend><b>Node</b></legend>
+					<select name="node_list" id="node_list"></select>
+				</fieldset>
+
+				<fieldset>
+					<legend><b>Command</b></legend>
+					<input type="text" size="30" id="command_entry" name="command_entry" class="modal_input" value="">
+					<hr>
+					<div>
+						<label id="windowfont" for="command_list">Saved Commands</label>
+						<select name="command_list" id="command_list" class="modal_input"></select>
+					</div>
 					<p align=center>
 						<button id="submit_button">Submit</button>
 					</p>
-					<script>
-						$(function() {
-							var option = '';
+				</fieldset>
 
-							$.get("/nodes?token=" + parent.token, function(data) {
-								for (var i in data.nodes) {
-									option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
-								}
+				<script>
+					$(function() {
+						var option = '';
 
-								option += '<option value="' + '*' + '">' + '*' + '</option>';
-								$('#node_list').append(option);
-							});
+						$.get("/nodes?token=" + parent.token, function(data) {
+							for (var i in data.nodes) {
+								option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
+							}
+
+							option += '<option value="' + '*' + '">' + '*' + '</option>';
+							$('#node_list').append(option);
 						});
-						$(function() {
-							var option = '';
+					});
+					$(function() {
+						var option = '';
 
-							$.post('/listcommands', {
-								token: parent.token
-							}, function(data) {
-								option += '<option value="' + 'Choose' + '">' + 'Choose' + '</option>';
-								if (data) {
-									data = JSON.parse(data);
-									for (var i = 0; i < data.length; i++) {
-										for (var key in data[i]) {
-											if (data[i].hasOwnProperty(key)) {
-												option += '<option value="' + data[i][key] + '">' + key + '</option>';
-											}
+						$.post('/listcommands', {
+							token: parent.token
+						}, function(data) {
+							option += '<option value="' + 'Choose' + '">' + 'Choose' + '</option>';
+							if (data) {
+								data = JSON.parse(data);
+								for (var i = 0; i < data.length; i++) {
+									for (var key in data[i]) {
+										if (data[i].hasOwnProperty(key)) {
+											option += '<option value="' + data[i][key] + '">' + key + '</option>';
 										}
 									}
 								}
+							}
 
-								$('#command_list').append(option);
-							});
+							$('#command_list').append(option);
 						});
-					</script>
+					});
+				</script>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Terminal</h2>
 			</div>
 
 			<div class="modal-body">
+				<textarea id="exec_output" name="command_output" value="" enctype="application/json"></textarea>
 				<div id="rerun_div">
-				  <button id="rerun_button">Run Again</button>
+					<button id="rerun_button">Run Again</button>
 				</div>
-				<br>
-				<textarea rows="20" cols="80" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
 			</div>
 		</div>
 	</div>
@@ -141,7 +143,5 @@
 		}
 
 		modal.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/functions-clear.html
+++ b/web/functions-clear.html
@@ -3,12 +3,12 @@
 	<script src="/assets/jquery.min.js"></script>
 	<link rel="stylesheet" href="/assets/jquery-ui.css">
 	<script src="/assets/jquery-ui.js"></script>
-	<script src="/assets/distLogo.js"></script>
 	<link rel="stylesheet" href="/assets/picluster-iframe.css">
+	<script src="/assets/distLogo.js"></script>
 	<script>
 		function exec() {
-			$.get("/prune?token=" + parent.token, function(data) {
-				var div = document.getElementById('modal-body2');
+			$.get("/clear-functions?token=" + parent.token, function(data) {
+				var div = document.getElementById('functions-clear-modal-body');
 				div.innerHTML = data.replace(/(?:\r\n|\r|\n)/g, '<br />');
 			});
 		}
@@ -17,19 +17,18 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-small">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
-				<h2>Cleaning stale Docker containers</h2>
+				<h2>Cleaning stale functions</h2>
 			</div>
-
-			<div id="modal-body2" class="modal-body">
+			<div id="functions-clear-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
-				</p>
 			</div>
 		</div>
 	</div>
+	</p>
 
 	<script>
 		var output_modal = document.getElementById('output');
@@ -38,11 +37,10 @@
 		output_span.onclick = function() {
 			output_modal.style.display = "none";
 		}
-
 		output_modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
+	</p>
+
 </html>

--- a/web/functions-create.html
+++ b/web/functions-create.html
@@ -26,53 +26,47 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Create a function</h2>
 			</div>
 
 			<div class="modal-body">
-				<p align=left>
-					<label>This module allows you to easilly create functions for testing purposes.</label>
-					<label>Please ensure that the container files are present on all the nodes.</label>
-					<br>
-					<fieldset name="functions" id="functions">
-						<legend>Enter the function name</legend>
-						<label><i>This should correspond to the container name in the Docker folder.</i></label>
-						<br><br>
-						<label>Name</label>
-						<input type="text" size="50" id="function-name" name="function-name" value=""></font>
-					</fieldset>
-					<fieldset name="options" id="options">
-						<legend>Container arguments (optional)</legend>
-						</select>
-						<label><i>Additional Docker arguments if needed such as ENVAR's or ports.</i></label>
-						<br><br>
-						<label>Arguments</label>
-						<input type="text" size="50" id="function-args" name="function-args" value=""></font>
-						<br><br>
-						<br>
-						<br>
-					</fieldset>
-					<p align=center>
-						<button id="submit_button">Create</button>
-					</p>
+				<label>Create functions for testing purposes.</label>
+				<fieldset name="functions" id="functions">
+					<legend><b>Function Name</b></legend>
+					<label><i>This should correspond to the container name in the Docker folder.</i></label>
+					<br><br>
+					<label>Name</label>
+					<input type="text" id="function-name" class="modal_input" name="function-name" value=""></font>
+				</fieldset>
+
+				<fieldset name="options" id="options">
+					<legend><b>Container Arguments</b> <i>(Optional)</i></legend>
+					</select>
+					<label><i>Additional Docker arguments if needed such as ENVAR's or ports.</i></label>
+					<br><br>
+					<label>Arguments</label>
+					<input type="text" id="function-args" class="modal_input" name="function-args" value=""></font>
+				</fieldset>
+
+				<p align=center>
+					<button id="submit_button">Create</button>
 				</p>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
-				<p align=center>
-					Sent request to create function.
+			<div id="functions-create-modal-body" class="modal-body">
+				Sent request to create function.
 			</div>
 		</div>
 	</div>
@@ -97,7 +91,5 @@
 		}
 
 		modal.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/functions-current.html
+++ b/web/functions-current.html
@@ -11,7 +11,7 @@
 		};
 
 		function exec() {
-			var div = document.getElementById('modal-body2');
+			var div = document.getElementById('functions-current-modal-body');
 			if (div) {
 				div.innerHTML = div.innerHTML + '<br><p align=center><img heigth="200" width="200" src="/assets/images/searching.jpg"><br><font size=+3><label>Searching for containers</label></font>';
 			}
@@ -36,13 +36,13 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Functions Awaiting Data Retrieval</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
+			<div id="functions-current-modal-body" class="modal-body">
 				<p align=center>
 			</div>
 		</div>
@@ -60,7 +60,5 @@
 		output_modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/functions-viewer.html
+++ b/web/functions-viewer.html
@@ -57,7 +57,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>View Functions</h2>
@@ -65,40 +65,35 @@
 
 			<div class="modal-body">
 				<fieldset name="functions" id="functions">
-					<legend>Select a Function</legend>
-					<div>
+					<legend><b>Function</b></legend>
+					<div id="function_list_selector">
 						<select name="function_list" id="function_list"></select>
 					</div>
-					<div>
+
+					<div id="function_list_submit">
 						<button id="submit_button">View</button>
 					</div>
 				</fieldset>
+
 				<fieldset name="options" id="options">
-					<legend>Function Data</legend>
+					<legend><b>Function Data</b></legend>
 					<label>Data Retrieval</label>
-					<input type="text" id="url" name="url" value="">
-					<br>
-					<label><i>If you execute the above command on your computer, you will not be able to see the output</i></label>
-					<br>
-					<label><i>here anymore because the function will be removed.</i></label>
-					<br>
-					<legend>Function Data</legend>
-					<textarea id="function_output" rows="15"></textarea>
+					<input type="text" id="url" name="url" class="modal_input" value="">
+					<textarea id="function_output"></textarea>
 				</fieldset>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
-				<p align=center>
-					Please wait......
+			<div id="functions-viewer-modal-body" class="modal-body">
+				Please wait.
 			</div>
 		</div>
 	</div>
@@ -125,7 +120,5 @@
 		modal.style.display = "block";
 
 		get_functions();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/heartbeat.html
+++ b/web/heartbeat.html
@@ -3,13 +3,13 @@
 	<script src="/assets/jquery.min.js"></script>
 	<link rel="stylesheet" href="/assets/jquery-ui.css">
 	<script src="/assets/jquery-ui.js"></script>
-	<link rel="stylesheet" href="/assets/picluster-iframe.css">
 	<script src="/assets/distLogo.js"></script>
+	<link rel="stylesheet" href="/assets/picluster-iframe.css">
 	<script>
 		function exec() {
-			$.get("/clear-functions?token=" + parent.token, function(data) {
-				var div = document.getElementById('modal-body2');
-				div.innerHTML = data.replace(/(?:\r\n|\r|\n)/g, '<br />');
+			$.get("/hb?token=" + parent.token, function(data) {
+				var div = document.getElementById('heartbeat-modal-body');
+				div.innerHTML = '\nSent request to do a manual heartbeat. Check the logs for the latest information.' + data;
 			});
 		}
 	</script>
@@ -17,18 +17,17 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
-				<h2>Cleaning stale functions</h2>
+				<h2>Running a heartbeat check on all containers</h2>
 			</div>
-			<div id="modal-body2" class="modal-body">
-				<p align=center>
-					Please wait......
+
+			<div id="heartbeat-modal-body" class="modal-body">
+				Please wait.
 			</div>
 		</div>
 	</div>
-	</p>
 
 	<script>
 		var output_modal = document.getElementById('output');
@@ -37,12 +36,13 @@
 		output_span.onclick = function() {
 			output_modal.style.display = "none";
 		}
+
+		output_span.onclick = function() {
+			output_modal.style.display = "none";
+		}
+
 		output_modal.style.display = "block";
 
 		exec();
-		
-		parent.resize_iframe_height();
 	</script>
-	</p>
-
 </html>

--- a/web/images-layout.html
+++ b/web/images-layout.html
@@ -11,7 +11,7 @@
 		};
 
 		function exec() {
-			var div = document.getElementById('modal-body2');
+			var div = document.getElementById('modal-body');
 			div.innerHTML = div ? div.innerHTML + '<br><p align=center><img heigth="200" width="200" src="/assets/images/searching.jpg"><br><font size=+3><label>Searching for images</label></font>' : '';
 
 			$.get("/nodes?token=" + parent.token, function(data) {
@@ -25,7 +25,7 @@
 						var array = check_data.data[i].images;
 						for (var j in array) {
 							if (array[j]) {
-								div.innerHTML += '<font size=+1><a href="/manage-images.html" style="text-decoration:none" onclick="linkFunction(\'' + array[j] + '\')">' + array[j] + '</a<</font><br><ol>';
+								div.innerHTML += '<font size=+1><a href="/images-manage.html" style="text-decoration:none" onclick="linkFunction(\'' + array[j] + '\')">' + array[j] + '</a<</font><br><ol>';
 							}
 						}
 					}
@@ -40,14 +40,13 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-small">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Images</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
-			</div>
+			<div id="modal-body" class="modal-body"></div>
 		</div>
 	</div>
 
@@ -62,7 +61,5 @@
 		output_modal.style.display = "block";
 
 		exec()
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/images-manage.html
+++ b/web/images-manage.html
@@ -19,7 +19,7 @@
 						token: parent.token,
 						image: image
 					}, function(data) {
-						var div = document.getElementById('modal-body2');
+						var div = document.getElementById('images-manage-modal-body');
 						div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.<br><br>';
 					});
 				} else {
@@ -28,7 +28,7 @@
 						image: image,
 						no_cache: no_cache
 					}, function(data) {
-						var div = document.getElementById('modal-body2');
+						var div = document.getElementById('images-manage-modal-body');
 						div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.<br><br>';
 					});
 				}
@@ -48,49 +48,51 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=left>
-					<fieldset>
-						<label for="image_list">Select a Container</label>
-						<select name="image_list" id="image_list"></select>
-						<br><br>
-						<input type="checkbox" id="cache"><label for="image_list">Build without Docker Cache</label>
-						<br><br>
-						<input type="checkbox" id="delete_image"><label for="image_list">Delete</label>
-						<br> <br>
-						<p align=center>
-							<button id="submit_button">Submit</button>
-						</p>
-						<script>
-							if (parent.manage_image) {
-								option += '<option value="' + parent.manage_image + '">' + parent.manage_image + '</option>';
-								$('#image_list').append(option);
-								parent.manage_image = '';
-							} else {
-								$(function() {
-									$.get("/nodes?token=" + parent.token, function(data) {
-										for (var i in data.container_list) {
-											option += '<option value="' + data.container_list[i] + '">' + data.container_list[i] + '</option>';
-										}
-										option += '<option value="' + '*' + '">' + '*' + '</option>';
-										$('#image_list').append(option);
-									});
-								});
-							}
-						</script>
-					</fieldset>
+				<fieldset id="image_list_fieldset">
+					<legend><b>Container</b></legend>
+					<select name="image_list" id="image_list"></select>
+				</fieldset>
+
+				<fieldset id="image_list_options_fieldset">
+					<legend><b>Options</b></legend>
+					<input type="checkbox" id="cache"><label for="image_list">Build without Docker Cache</label>
+					<br>
+					<input type="checkbox" id="delete_image"><label for="image_list">Delete</label>
+				</fieldset>
+
+				<p align=center>
+					<button id="submit_button">Submit</button>
 				</p>
+
+				<script>
+					if (parent.manage_image) {
+						option += '<option value="' + parent.manage_image + '">' + parent.manage_image + '</option>';
+						$('#image_list').append(option);
+						parent.manage_image = '';
+					} else {
+						$(function() {
+							$.get("/nodes?token=" + parent.token, function(data) {
+								for (var i in data.container_list) {
+									option += '<option value="' + data.container_list[i] + '">' + data.container_list[i] + '</option>';
+								}
+								option += '<option value="' + '*' + '">' + '*' + '</option>';
+								$('#image_list').append(option);
+							});
+						});
+					}
+				</script>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
+			<div id="images-manage-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
 				</p>
@@ -121,7 +123,5 @@
 	  }
 
   	modal.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/images-prune.html
+++ b/web/images-prune.html
@@ -7,9 +7,9 @@
 	<link rel="stylesheet" href="/assets/picluster-iframe.css">
 	<script>
 		function exec() {
-			$.get("/hb?token=" + parent.token, function(data) {
-				var div = document.getElementById('modal-body2');
-				div.innerHTML = '\nSent request to do a manual heartbeat. Check the logs for the latest information.' + data;
+			$.get("/prune?token=" + parent.token, function(data) {
+				var div = document.getElementById('images-prune-modal-body');
+				div.innerHTML = data.replace(/(?:\r\n|\r|\n)/g, '<br />');
 			});
 		}
 	</script>
@@ -20,10 +20,10 @@
 		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
-				<h2>Running a heartbeat check on all containers</h2>
+				<h2>Cleaning stale Docker containers</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
+			<div id="images-prune-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
 				</p>
@@ -39,14 +39,8 @@
 			output_modal.style.display = "none";
 		}
 
-		output_span.onclick = function() {
-			output_modal.style.display = "none";
-		}
-
 		output_modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/images-pull.html
+++ b/web/images-pull.html
@@ -24,7 +24,7 @@
 
 		var command = ["docker", "image", "pull", image].join(' ');
 		var nodes = document.getElementsByName('host_list');
-		var div = document.getElementById('modal-body2');
+		var div = document.getElementById('images-pull-modal-body');
 		var username = document.getElementsByName('imageauth-user')[0].value || '';
 		var password = document.getElementsByName('imageauth-password')[0].value || '';
 
@@ -55,7 +55,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Pull Images</h2>
@@ -64,31 +64,31 @@
 			<div class="modal-body">
 				<div id="container" title="Pull Images">
 					<fieldset>
-						<label for="container_list">Select Registry</label>
-						<select name="container_list" id="container_list" onchange="clearAuth()">
-							</select>
-						<legend>Authentication (optional)</legend>
+						<legend><b>Authentication</b> <i>(Optional)</i></legend>
+						<label for="container_list">Registry</label>
+						<select name="container_list" class="modal_input" id="container_list" onchange="clearAuth()"></select>
 						<br>
 						<label for="imageauth-user">Username</label>
-						<input type="text" name="imageauth-user" id="imageauth-user" />
+						<input type="text" name="imageauth-user" id="imageauth-user" class="modal_input" />
+						<br>
 						<label for="imageauth-password">Password</label>
-						<input type="password" name="imageauth-password" id="imageauth-password" />
+						<input type="password" name="imageauth-password" id="imageauth-password" class="modal_input" />
 					</fieldset>
-					<br>
+
 					<fieldset name="options" id="options">
-						<legend>Images</legend>
+						<legend><b>Images</b></legend>
 						<p id="imageDescription" style="visibility: hidden;margin: 0;padding: 0;"></p>
-						<label for="image">Image: </label>
+						<label for="image">Image</label>
 						<input id="image">
-						<label for="imageTags">Tags: </label>
+						<label for="imageTags">Tags</label>
 						<select id="imageTags" disabled="disabled">
 								<option value="latest" selected="selected">Latest</option>
 							</select>
 					</fieldset>
 					<fieldset name="host_list" id="host_list">
-						<legend>Nodes:</legend>
-						<label for="host_list">All</label><input type="checkbox" name="host_list" onClick="checkAll(this);" checked="checked"/>
-						&nbsp;&nbsp;&nbsp;&nbsp;
+						<legend><b>Nodes</b></legend>
+						<input type="checkbox" name="host_list" onClick="checkAll(this);" checked="checked"/>
+						<label for="host_list">All</label><br>
 					</fieldset>
 					<p align=center>
 						<button onclick="exec()" id="submit_button"> Submit</button>
@@ -133,7 +133,7 @@
 								var option = '';
 
 								for (var i = 0; i < data.nodes.length; i++) {
-									option += '<label for="host_list">' + data.nodes[i] + '</label><input type="checkbox" name="host_list" checked="checked" value="' + data.nodes[i] + '" />&nbsp;&nbsp;&nbsp;&nbsp;';
+									option += '<input type="checkbox" name="host_list" checked="checked" value="' + data.nodes[i] + '" /><label for="host_list">' + data.nodes[i] + '</label><br>';
 								}
 
 								$('#host_list').append(option);
@@ -234,15 +234,14 @@
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
-				<p align=center>
-					Please wait......
+			<div id="images-pull-modal-body" class="modal-body">
+				Please wait.
 			</div>
 		</div>
 	</div>
@@ -271,7 +270,5 @@
 	}
 
 	modal.style.display = "block";
-
-	parent.resize_iframe_height();
 </script>
 </html>

--- a/web/images-upload.html
+++ b/web/images-upload.html
@@ -3,21 +3,8 @@
 	<script src="/assets/jquery.min.js"></script>
 	<link rel="stylesheet" href="/assets/jquery-ui.css">
 	<script src="/assets/jquery-ui.js"></script>
-  <link rel="stylesheet" href="/assets/picluster-iframe.css">
-	<script>
-		function exec() {
-			var path = '/addhost';
-			var host = $("#host").val();
-
-			$.post(path, {
-				token: parent.token,
-				host: host
-			}, function(data) {
-				var div = document.getElementById('modal-body2');
-				div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.\n' + data;
-			});
-		}
-	</script>
+	<link rel="stylesheet" href="/assets/picluster-iframe.css">
+	<script src="/assets/dropzone.js"></script>
 </head>
 
 <body>
@@ -25,35 +12,41 @@
 		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
-				<h2>Add a host to PiCluster</h2>
+				<h2>Upload Dockerfile Archive</h2>
 			</div>
+
 			<div class="modal-body">
 				<p align=left>
-					<label id="windowfont">This will add a new host to the PiCluster configuration file.</label>
-					<br><br><br>
-					<label id="windowfont"><b>Host Name or IP:</b></label>
-					<input type="text" size="30" id="host" name="host" value=""></font>
+					<label id="windowfont">This will upload a .zip archive of a containers Dockerfile and required files.
+				  <br><br>
+					The .zip archive will be copied to each node and extracted in the Docker directory.
+						<br><br>
+					<form id="upload-widget" method="post" action="/upload" class="dropzone">
+					<input type="hidden" name="token" id="token">
+					</form>
 					<br><br>
-					<p align=center>
-						<button id="submit_button">Submit</button>
-					</p>
+					</fieldset>
+					<script>
+					 document.getElementById("token").value = parent.token;
+					</script>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
-			<div id="modal-body2" class="modal-body">
+
+			<div id="images-upload-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
+				</p>
 			</div>
 		</div>
 	</div>
-	</p>
 
 	<script>
 		var modal = document.getElementById('modal_container');
@@ -70,14 +63,6 @@
 			output_modal.style.display = "none";
 		}
 
-		submit_button.onclick = function() {
-			modal.style.display = "none";
-			output_modal.style.display = "block";
-			exec();
-		}
-
 		modal.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -65,19 +65,20 @@
 			document.getElementById("div_iframe").style.height = document.getElementById("iframe_a").contentWindow.document.body.scrollHeight + "px";
 		}
 
-		function resize_iframe_height(iframe) {
+		/*function resize_iframe_height(iframe) {
 			document.getElementById("div_iframe").style.height = "calc(100% - 4vw)";
 		}
+    */
 
 		$(document).ready(function() {
-			$('#sandbox').click(function() {
-				$('#iframe_a').attr('src', '/sandbox.html?token=' + token);
+			$('#exec').click(function() {
+				$('#iframe_a').attr('src', '/exec.html?token=' + token);
 			});
 			$('#terminal').click(function() {
 				$('#iframe_a').attr('src', '/terminal.html?token=' + token);
 			});
-			$('#image-layout').click(function() {
-				$('#iframe_a').attr('src', '/image-layout.html');
+			$('#images-layout').click(function() {
+				$('#iframe_a').attr('src', '/images-layout.html');
 			});
 			$('#syslog').click(function() {
 				$('#iframe_a').attr('src', '/syslog.html');
@@ -92,64 +93,61 @@
 				$('#iframe_a').attr('src', '/functions-create.html');
 			});
 			$('#functions-remove').click(function() {
-				$('#iframe_a').attr('src', '/clear-functions.html');
+				$('#iframe_a').attr('src', '/functions-clear.html');
 			});
 			$('#functions-current').click(function() {
-				$('#iframe_a').attr('src', '/current-functions.html');
+				$('#iframe_a').attr('src', '/functions-current.html');
 			});
 			$('#rsyslog').click(function() {
 				$('#iframe_a').attr('src', '/rsyslog.html');
 			});
-			$('#nodes').click(function() {
-				$('#iframe_a').attr('src', '/nodes.html');
+			$('#nodes-list').click(function() {
+				$('#iframe_a').attr('src', '/nodes-list.html');
 			});
-			$('#layout').click(function() {
-				$('#iframe_a').attr('src', '/container-layout.html');
+			$('#containers-layout').click(function() {
+				$('#iframe_a').attr('src', '/containers-layout.html');
 			});
-			$('#addcontainer').click(function() {
-				$('#iframe_a').attr('src', '/addcontainer.html');
+			$('#containers-add').click(function() {
+				$('#iframe_a').attr('src', '/containers-add.html');
 			});
-			$('#addhost').click(function() {
-				$('#iframe_a').attr('src', '/addhost.html');
+			$('#node-add').click(function() {
+				$('#iframe_a').attr('src', '/nodes-add.html');
 			});
-			$('#rmhost').click(function() {
-				$('#iframe_a').attr('src', '/rmhost.html');
+			$('#node-remove').click(function() {
+				$('#iframe_a').attr('src', '/nodes-remove.html');
 			});
-			$('#editconfig').click(function() {
-				$('#iframe_a').attr('src', '/editconfig.html?token=' + token);
+			$('#config-edit').click(function() {
+				$('#iframe_a').attr('src', '/config-edit.html?token=' + token);
 			});
 			$('#log').click(function() {
 				$('#iframe_a').attr('src', '/log.html');
 			});
-			$('#hb').click(function() {
-				$('#iframe_a').attr('src', '/hb.html');
+			$('#heartbeat').click(function() {
+				$('#iframe_a').attr('src', '/heartbeat.html');
 			});
 			$('#docs').click(function() {
 				$('#iframe_a').attr('src', '/docs.html');
 			});
-			$('#upload').click(function() {
-				$('#iframe_a').attr('src', '/upload.html');
+			$('#images-upload').click(function() {
+				$('#iframe_a').attr('src', '/images-upload.html');
 			});
-			$('#pull').click(function() {
-				$('#iframe_a').attr('src', '/pullimages.html');
+			$('#images-pull').click(function() {
+				$('#iframe_a').attr('src', '/images-pull.html');
 			});
-			$('#build').click(function() {
-				$('#iframe_a').attr('src', '/manage-images.html');
+			$('#images-manage').click(function() {
+				$('#iframe_a').attr('src', '/images-manage.html');
 			});
-			$('#stop').click(function() {
-				$('#iframe_a').attr('src', '/stop.html');
-			});
-			$('#reloadconfig').click(function() {
-				$('#iframe_a').attr('src', '/reloadconfig.html');
+			$('#config-reload').click(function() {
+				$('#iframe_a').attr('src', '/config-reload.html');
 			});
 			$('#killvip').click(function() {
 				$('#iframe_a').attr('src', '/killvip.html');
 			});
-			$('#manage').click(function() {
-				$('#iframe_a').attr('src', '/manage.html');
+			$('#containers-manage').click(function() {
+				$('#iframe_a').attr('src', '/containers-manage.html');
 			});
-			$('#prune').click(function() {
-				$('#iframe_a').attr('src', '/prune.html');
+			$('#images-prune').click(function() {
+				$('#iframe_a').attr('src', '/images-prune.html');
 			});
 			$('#terminal').click(function() {
 				$('#iframe_a').attr('src', '/terminal.html');
@@ -158,7 +156,7 @@
 			//	$('#iframe_a').attr('src', '/docs.html?doc_id=doc1');
 			//});
 
-			build_doc_links();
+			images-manage_doc_links();
 
 		});
 
@@ -244,34 +242,34 @@
 				<li id="nav_logo"><a href='/blank.html' target="iframe_a" id="logo"><img src="/assets/images/sphere.png" id="nav_logo_image"></a>
 				<li id="nav_system"><a onmouseover="this.click()" href="#!">System</a>
 					<ul class="dropdown">
-						<li><a href="#" id="nodes">Nodes</a></li>
-						<li><a href="#" id="editconfig">Edit Configuration</a></li>
-						<li><a href="#" id="reloadconfig">Reload Configuration</a></li>
-						<li><a href="#" id="addhost">Add Host</a></li>
-						<li><a href="#" id="rmhost">Remove Host</a></li>
+						<li><a href="#" id="nodes-list">Nodes</a></li>
+						<li><a href="#" id="node-add">Add Node</a></li>
+						<li><a href="#" id="node-remove">Remove Node</a></li>
+						<li><a href="#" id="config-edit">Edit Config</a></li>
+						<li><a href="#" id="config-reload">Reload Config</a></li>
 					</ul>
 				</li>
 				<li id="nav_containers"><a onmouseover="this.click()" href="#!">Containers</a>
 					<ul class="dropdown">
-						<li><a href="#" id="layout">Running</a></li>
-						<li><a href="#" id="manage">Manage</a></li>
-						<li><a href="#" id="addcontainer">Add</a></li>
+						<li><a href="#" id="containers-layout">Running</a></li>
+						<li><a href="#" id="containers-manage">Manage</a></li>
+						<li><a href="#" id="containers-add">Add</a></li>
 					</ul>
 				</li>
 				<li id="nav_images"><a onmouseover="this.click()" href="#!">Images</a>
 					<ul class="dropdown">
-						<li><a href="#" id="pull">Pull</a></li>
-						<li><a href="#" id="build">Manage</a></li>
-						<li><a href="#" id="image-layout">List</a></li>
-						<li><a href="#" id="upload">Upload Files</a></li>
+						<li><a href="#" id="images-pull">Pull</a></li>
+						<li><a href="#" id="images-manage">Manage</a></li>
+						<li><a href="#" id="images-layout">List</a></li>
+						<li><a href="#" id="images-upload">Upload</a></li>
 					</ul>
 				</li>
 				<li id="nav_operations"><a onmouseover="this.click()" href="#!">Operations</a>
 					<ul class="dropdown">
 						<li><a href="#" id="killvip">Reset Virtual IP</a></li>
-						<li><a href="#" id="sandbox">Run Command(s)</a></li>
-						<li><a href="#" id="hb">Heartbeat</a></li>
-						<li><a href="#" id="prune">Clean Docker</a></li>
+						<li><a href="#" id="exec">Run Command(s)</a></li>
+						<li><a href="#" id="heartbeat">Heartbeat</a></li>
+						<li><a href="#" id="images-prune">Clean Docker</a></li>
 						<li><a href="#" id="terminal">Terminal</a></li>
 						<li><a href="#" id="kibana">Kibana</a></li>
 					</ul>

--- a/web/killvip.html
+++ b/web/killvip.html
@@ -8,7 +8,7 @@
 	<script>
 		function exec() {
 			$.get("/killvip?token=" + parent.token, function(data) {
-				var div = document.getElementById('modal-body2');
+				var div = document.getElementById('killvip-modal-body');
 				div.innerHTML = 'Sent request to delete the VIP from each host. The IP should be restored when the next VIP check is run.' + data;
 			});
 		}
@@ -23,9 +23,9 @@
 				<h2>Resetting VIP on all hosts</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
+			<div id="kill-vip-modal-body" class="modal-body">
 				<p align=center>
-					Please wait......
+					Please wait.
 				</p>
 			</div>
 		</div>
@@ -42,7 +42,5 @@
 		output_modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/log.html
+++ b/web/log.html
@@ -17,14 +17,16 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Log</h2>
 			</div>
 
 			<div class="modal-body">
-				<textarea rows="20" cols="80" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
+				<div id="log_output">
+					<textarea id="command_output" name="command_output" value="" enctype="application/json"></textarea>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -40,7 +42,5 @@
 		output_modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/nodes-add.html
+++ b/web/nodes-add.html
@@ -3,8 +3,21 @@
 	<script src="/assets/jquery.min.js"></script>
 	<link rel="stylesheet" href="/assets/jquery-ui.css">
 	<script src="/assets/jquery-ui.js"></script>
-	<link rel="stylesheet" href="/assets/picluster-iframe.css">
-	<script src="/assets/dropzone.js"></script>
+  <link rel="stylesheet" href="/assets/picluster-iframe.css">
+	<script>
+		function exec() {
+			var path = '/addhost';
+			var host = $("#host").val();
+
+			$.post(path, {
+				token: parent.token,
+				host: host
+			}, function(data) {
+				var div = document.getElementById('nodes-add-modal-body');
+				div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.\n' + data;
+			});
+		}
+	</script>
 </head>
 
 <body>
@@ -12,41 +25,34 @@
 		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
-				<h2>Upload Dockerfile Archive</h2>
+				<h2>Add a host to PiCluster</h2>
 			</div>
-
 			<div class="modal-body">
-				<p align=left>
-					<label id="windowfont">This will upload a .zip archive of a containers Dockerfile and required files.
-				  <br><br>
-					The .zip archive will be copied to each node and extracted in the Docker directory.
-						<br><br>
-					<form id="upload-widget" method="post" action="/upload" class="dropzone">
-					<input type="hidden" name="token" id="token">
-					</form>
-					<br><br>
-					</fieldset>
-					<script>
-					 document.getElementById("token").value = parent.token;
-					</script>
+				<p class="modal-description">
+					Add a new host to PiCluster config file.
+				</p>
+				<div id="host_add">
+					<label id="windowfont"><b>Host or IP</b></label>
+					<input type="text" id="host" name="host" value="">
+					<button id="submit_button">Submit</button>
+				</div>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
-
-			<div id="modal-body2" class="modal-body">
+			<div id="nodes-add-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
-				</p>
 			</div>
 		</div>
 	</div>
+	</p>
 
 	<script>
 		var modal = document.getElementById('modal_container');
@@ -63,8 +69,12 @@
 			output_modal.style.display = "none";
 		}
 
-		modal.style.display = "block";
+		submit_button.onclick = function() {
+			modal.style.display = "none";
+			output_modal.style.display = "block";
+			exec();
+		}
 
-		parent.resize_iframe_height();
+		modal.style.display = "block";
 	</script>
 </html>

--- a/web/nodes-list.html
+++ b/web/nodes-list.html
@@ -8,7 +8,7 @@
 	<link rel="stylesheet" href="/assets/picluster-iframe.css">
 	<script>
 		function exec() {
-			var div = document.getElementById('modal-body2');
+			var div = document.getElementById('nodes-list-modal-body');
 			div ? div.innerHTML = div.innerHTML + '<br><p align=center><img heigth="200" width="200" src="/assets/images/searching.jpg"><br><font size=+3><label>Searching for nodes</label></font>' : div;
 
 			$.get("/nodes?token=" + parent.token, function(data) {
@@ -109,7 +109,7 @@
 						node_card.appendChild(div_memory);
 
 						var hr = document.createElement('hr');
-						
+
 						div.appendChild(node_card);
 						div.appendChild(hr);
 					}
@@ -122,14 +122,13 @@
 
 <body>
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Nodes</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
-				<p align=center></p>
+			<div id="nodes-list-modal-body" class="modal-body">
 			</div>
 		</div>
 	</div>
@@ -145,7 +144,5 @@
 	  output_modal.style.display = "block";
 
 		exec()
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/nodes-remove.html
+++ b/web/nodes-remove.html
@@ -15,7 +15,7 @@
 				token: parent.token,
 				host: host
 			}, function(data) {
-				var div = document.getElementById('modal-body2');
+				var div = document.getElementById('nodes-remove-modal-body');
 				div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.\n' + data;
 			});
 		}
@@ -31,38 +31,35 @@
 			</div>
 
 			<div class="modal-body">
-				<p align=left>
-					<label id="windowfont">This will remove a host from the PiCluster configuration file. Please stop any running containers</label>
-					<label id="windowfont">on the host before removing it.</label>
-					<br><br>
+				<p class="modal-description">
+					Remove a host from the PiCluster config file.
+				</p>
+				<div id="node_list_remove">
 					<label id="windowfont" for="node_list"><b>Select a Node</b></label>
 					<select name="node_list" id="node_list"></select>
-					<br><br>
-					<p align=center>
-						<button id="submit_button">Submit</button>
-					</p>
-					<script>
-						var option = '';
-						$.get("/nodes?token=" + parent.token, function(data) {
-							for (var i in data.nodes) {
-								option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
-							}
-							$('#node_list').append(option);
-						});
-					</script>
-				</p>
+					<button id="submit_button">Submit</button>
+				</div>
+				<script>
+					var option = '';
+					$.get("/nodes?token=" + parent.token, function(data) {
+						for (var i in data.nodes) {
+							option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
+						}
+						$('#node_list').append(option);
+					});
+				</script>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>Command Output</h2>
 			</div>
 
-			<div id="modal-body2" class="modal-body">
+			<div id="nodes-remove-modal-body" class="modal-body">
 				<p align=center>
 					Please wait......
 				</p>
@@ -92,7 +89,5 @@
 		}
 
 		modal.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/rsyslog.html
+++ b/web/rsyslog.html
@@ -43,7 +43,7 @@
 <body>
 	<div id="modal_container" class="modal">
 		<div class="modal-body">
-			<div class="modal-content modal-medium">
+			<div class="modal-content modal-large">
 				<div class="modal-header">
 					<span class="close">&times;</span>
 					<h2>PiCluster Rsyslog Viewer</h2>
@@ -75,7 +75,7 @@
 					</div>
 
 					<div id="log_output">
-						<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
+						<textarea id="command_output" name="command_output" value="" enctype="application/json"></textarea>
 					</div>
 				</div>
 			</div>
@@ -98,7 +98,5 @@
 		modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/syslog.html
+++ b/web/syslog.html
@@ -43,7 +43,7 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Syslog Viewer</h2>
@@ -75,7 +75,7 @@
 				</div>
 
 				<div id="log_output">
-					<textarea rows="25" cols="74" id="command_output" name="command_output" value="" enctype="application/json"></textarea>
+					<textarea id="command_output" name="command_output" value="" enctype="application/json"></textarea>
 				</div>
 			</div>
 		</div>
@@ -97,7 +97,5 @@
 		modal.style.display = "block";
 
 		exec();
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/terminal.html
+++ b/web/terminal.html
@@ -47,53 +47,48 @@
 
 <body>
 	<div id="modal_container" class="modal">
-		<div class="modal-content modal-medium">
+		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Terminal</h2>
 			</div>
 
 			<div class="modal-body">
-				<p align=left>
-					<label for="node_list"><b>Select a Node</b></label>
+				<fieldset>
+					<legend><b>Node</b></legend>
 					<select name="node_list" id="node_list"></select>
-					<br><br>
-					<p align=center>
-						<button id="submit_button">Submit</button>
-					</p>
-					<script>
-						$(function() {
-							var option = '';
-							$.get("/nodes?token=" + parent.token, function(data) {
-								for (var i in data.nodes) {
-									option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
-								}
-								$('#node_list').append(option);
-							});
-						});
-					</script>
+				</fieldset>
+
+				<p align=center>
+					<button id="submit_button">Submit</button>
 				</p>
+
+				<script>
+					$(function() {
+						var option = '';
+						$.get("/nodes?token=" + parent.token, function(data) {
+							for (var i in data.nodes) {
+								option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
+							}
+							$('#node_list').append(option);
+						});
+					});
+				</script>
 			</div>
 		</div>
 	</div>
 
 	<div id="output" class="modal">
-		<div id="terminal_modal" class="modal-content modal-medium">
+		<div id="terminal_modal" class="modal-content modal-large">
 			<div class="modal-header">
 				<span class="close">&times;</span>
 				<h2>PiCluster Terminal</h2>
 			</div>
 
 			<div class="modal-body">
-				<table style="width:100%;">
-					<tr>
-						<td>
-							<div id="terminal_container">
-								<div id="terminal"></div>
-							</div>
-						</td>
-					</tr>
-				</table>
+				<div id="terminal_container">
+					<div id="terminal"></div>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -120,7 +115,5 @@
 		}
 
 		modal.style.display = "block";
-
-		parent.resize_iframe_height();
 	</script>
 </html>

--- a/web/tests/integration/main.js
+++ b/web/tests/integration/main.js
@@ -1,7 +1,7 @@
 /* eslint-env phantomjs,browser */
 /* eslint-disable func-names */
 /* global casper,$ */
-casper.test.begin('main.html', 7, test => {
+casper.test.begin('index.html', 7, test => {
   const URL = casper.cli.get('url');
   const username = casper.cli.get('username');
   const password = casper.cli.get('password');

--- a/web/tests/integration/nodes.js
+++ b/web/tests/integration/nodes.js
@@ -3,7 +3,7 @@
 /* global casper */
 casper.options.waitTimeout = 20000;
 
-casper.test.begin('nodes.html', 2, test => {
+casper.test.begin('nodes-list.html', 2, test => {
   const URL = casper.cli.get('url');
   const username = casper.cli.get('username');
   const password = casper.cli.get('password');
@@ -26,7 +26,7 @@ casper.test.begin('nodes.html', 2, test => {
 
     this.page.switchToChildFrame(0);
 
-    test.assertEquals(iframe, URL + '/nodes.html', 'The iframes source should equal ' + URL + '/nodes.html');
+    test.assertEquals(iframe, URL + '/nodes-list.html', 'The iframes source should equal ' + URL + '/nodes-list.html');
 
     if (lib.getCasperEngine() === 'slimerjs') {
       this.waitForSelector('.node_status_logo', function () {

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -85,7 +85,7 @@ function serve_doc_pages() {
   }
 }
 
-app.get('/sandbox.html', (req, res) => {
+app.get('/exec.html', (req, res) => {
   const check_token = req.query.token;
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
@@ -94,12 +94,12 @@ app.get('/sandbox.html', (req, res) => {
   }
 });
 
-app.get('/editconfig.html', (req, res) => {
+app.get('/config-edit.html', (req, res) => {
   const check_token = req.query.token;
   if ((check_token !== token) || (!check_token)) {
     res.end('\nError: Invalid Credentials');
   } else {
-    res.sendFile(__dirname + '/editconfig.html');
+    res.sendFile(__dirname + '/config-edit.html');
   }
 });
 
@@ -1036,22 +1036,22 @@ app.get('/getconfig', (req, res) => {
 });
 
 app.get('/', (req, res) => {
-  res.sendFile(__dirname + '/main.html');
+  res.sendFile(__dirname + '/index.html');
 });
 app.get('/blank.html', (req, res) => {
   res.sendFile(__dirname + '/blank.html');
 });
-app.get('/nodes.html', (req, res) => {
-  res.sendFile(__dirname + '/nodes.html');
+app.get('/nodes-list.html', (req, res) => {
+  res.sendFile(__dirname + '/nodes-list.html');
 });
-app.get('/container-layout.html', (req, res) => {
-  res.sendFile(__dirname + '/container-layout.html');
+app.get('/containers-layout.html', (req, res) => {
+  res.sendFile(__dirname + '/containers-layout.html');
 });
-app.get('/prune.html', (req, res) => {
-  res.sendFile(__dirname + '/prune.html');
+app.get('/images-prune.html', (req, res) => {
+  res.sendFile(__dirname + '/images-prune.html');
 });
-app.get('/clear-functions.html', (req, res) => {
-  res.sendFile(__dirname + '/clear-functions.html');
+app.get('/functions-clear.html', (req, res) => {
+  res.sendFile(__dirname + '/functions-clear.html');
 });
 app.get('/functions-viewer.html', (req, res) => {
   res.sendFile(__dirname + '/functions-viewer.html');
@@ -1059,26 +1059,26 @@ app.get('/functions-viewer.html', (req, res) => {
 app.get('/functions-create.html', (req, res) => {
   res.sendFile(__dirname + '/functions-create.html');
 });
-app.get('/current-functions.html', (req, res) => {
-  res.sendFile(__dirname + '/current-functions.html');
+app.get('/functions-current.html', (req, res) => {
+  res.sendFile(__dirname + '/functions-current.html');
 });
-app.get('/reloadconfig.html', (req, res) => {
-  res.sendFile(__dirname + '/reloadconfig.html');
+app.get('/config-reload.html', (req, res) => {
+  res.sendFile(__dirname + '/config-reload.html');
 });
-app.get('/pullimages.html', (req, res) => {
-  res.sendFile(__dirname + '/pullimages.html');
+app.get('/images-pull.html', (req, res) => {
+  res.sendFile(__dirname + '/images-pull.html');
 });
-app.get('/manage-images.html', (req, res) => {
-  res.sendFile(__dirname + '/manage-images.html');
+app.get('/images-manage.html', (req, res) => {
+  res.sendFile(__dirname + '/images-manage.html');
 });
-app.get('/image-layout.html', (req, res) => {
-  res.sendFile(__dirname + '/image-layout.html');
+app.get('/images-layout.html', (req, res) => {
+  res.sendFile(__dirname + '/images-layout.html');
 });
 app.get('/log.html', (req, res) => {
   res.sendFile(__dirname + '/log.html');
 });
-app.get('/hb.html', (req, res) => {
-  res.sendFile(__dirname + '/hb.html');
+app.get('/heartbeat.html', (req, res) => {
+  res.sendFile(__dirname + '/heartbeat.html');
 });
 app.get('/killvip.html', (req, res) => {
   res.sendFile(__dirname + '/killvip.html');
@@ -1086,20 +1086,20 @@ app.get('/killvip.html', (req, res) => {
 app.get('/syslog.html', (req, res) => {
   res.sendFile(__dirname + '/syslog.html');
 });
-app.get('/manage.html', (req, res) => {
-  res.sendFile(__dirname + '/manage.html');
+app.get('/containers-manage.html', (req, res) => {
+  res.sendFile(__dirname + '/containers-manage.html');
 });
 app.get('/terminal.html', (req, res) => {
   res.sendFile(__dirname + '/terminal.html');
 });
-app.get('/addcontainer.html', (req, res) => {
-  res.sendFile(__dirname + '/addcontainer.html');
+app.get('/containers-add.html', (req, res) => {
+  res.sendFile(__dirname + '/containers-add.html');
 });
-app.get('/addhost.html', (req, res) => {
-  res.sendFile(__dirname + '/addhost.html');
+app.get('/nodes-add.html', (req, res) => {
+  res.sendFile(__dirname + '/nodes-add.html');
 });
-app.get('/rmhost.html', (req, res) => {
-  res.sendFile(__dirname + '/rmhost.html');
+app.get('/nodes-remove.html', (req, res) => {
+  res.sendFile(__dirname + '/nodes-remove.html');
 });
 app.get('/rsyslog.html', (req, res) => {
   res.sendFile(__dirname + '/rsyslog.html');
@@ -1110,8 +1110,8 @@ app.get('/favicon.ico', (req, res) => {
 app.get('/docs.html', (req, res) => {
   res.sendFile(__dirname + '/docs.html');
 });
-app.get('/upload.html', (req, res) => {
-  res.sendFile(__dirname + '/upload.html');
+app.get('/images-upload.html', (req, res) => {
+  res.sendFile(__dirname + '/images-upload.html');
 });
 
 serve_doc_pages();


### PR DESCRIPTION
This PR fixes the UI problems reported in issue #94. While fixing the UI errors, I tidied up the UI to make it more consistent. One thing was removing the #modal-body2 CSS id, which was overused. CSS ids are supposed to be unique per HTML tag; if using a CSS element across multiple HTML tags, use a CSS class instead.

Also, I had some free time on a plane to dive a little deeper. The liquor told me that the file naming sucked, so I spent a few hours renaming HTML files into more logical. The files are grouped into containers, images, config, and nodes. 

Additionally, I have renamed add instances of "hosts" to "nodes". The terms used in PiCluster should be documented thoroughly; Nodes for machines running containers, Containers for services running in docker, Images for prebuilt docker services, etc etc. 