### PR TITLE
Add merged node section combining add and remove together

### DIFF
--- a/web/assets/picluster-iframe.css
+++ b/web/assets/picluster-iframe.css
@@ -117,7 +117,8 @@ fieldset {
 
 .modal-small {
   width: 44%;
-  min-width: 370px
+  min-width: 370px;
+  min-height: 400px;
 }
 
 .modal-large {
@@ -137,7 +138,7 @@ fieldset {
   padding: 1px 10px 10px;
   color: black;
   font-size: 18px;
-  white-space: nowrap;
+  max-height: 90%;
 }
 
 .modal_input {
@@ -320,6 +321,13 @@ fieldset {
   margin-right: 5px;
 }
 
+#node {
+  font-size: 18px;
+  width: 50%;
+  display: inline;
+  margin-right: 5px;
+}
+
 #node_add {}
 #node_remove {}
 
@@ -465,7 +473,12 @@ fieldset {
 #functions-viewer-modal-body {}
 #heartbeat-modal-body {}
 #images-manage-modal-body {}
-#images-prune-modal-body {}
+
+#images-prune-modal-body {
+  overflow-y: scroll;
+  white-space: nowrap;
+}
+
 #images-pull-modal-body {}
 #images-upload-modal-body {}
 #killvip-modal-body {}

--- a/web/index.html
+++ b/web/index.html
@@ -117,6 +117,9 @@
 			$('#node-remove').click(function() {
 				$('#iframe_a').attr('src', '/nodes-remove.html');
 			});
+			$('#node-manage').click(function() {
+				$('#iframe_a').attr('src', '/nodes-manage.html');
+			});
 			$('#config-edit').click(function() {
 				$('#iframe_a').attr('src', '/config-edit.html?token=' + token);
 			});
@@ -242,23 +245,22 @@
 				<li id="nav_system"><a onmouseover="this.click()" href="#!">System</a>
 					<ul class="dropdown">
 						<li><a href="#" id="nodes-list">Nodes</a></li>
-						<li><a href="#" id="node-add">Add Node</a></li>
-						<li><a href="#" id="node-remove">Remove Node</a></li>
+						<li><a href="#" id="node-manage">Manage</a></li>
 						<li><a href="#" id="config-edit">Edit Config</a></li>
 					</ul>
 				</li>
 				<li id="nav_containers"><a onmouseover="this.click()" href="#!">Containers</a>
 					<ul class="dropdown">
-						<li><a href="#" id="containers-layout">Running</a></li>
+						<li><a href="#" id="containers-layout">List</a></li>
 						<li><a href="#" id="containers-manage">Manage</a></li>
 						<li><a href="#" id="containers-add">Add</a></li>
 					</ul>
 				</li>
 				<li id="nav_images"><a onmouseover="this.click()" href="#!">Images</a>
 					<ul class="dropdown">
-						<li><a href="#" id="images-pull">Pull</a></li>
-						<li><a href="#" id="images-manage">Manage</a></li>
 						<li><a href="#" id="images-layout">List</a></li>
+						<li><a href="#" id="images-manage">Manage</a></li>
+						<li><a href="#" id="images-pull">Pull</a></li>
 						<li><a href="#" id="images-upload">Upload</a></li>
 					</ul>
 				</li>

--- a/web/nodes-add.html
+++ b/web/nodes-add.html
@@ -7,11 +7,11 @@
 	<script>
 		function exec() {
 			var path = '/addhost';
-			var host = $("#host").val();
+			var node = $("#node").val();
 
 			$.post(path, {
 				token: parent.token,
-				host: host
+				host: node
 			}, function(data) {
 				var div = document.getElementById('nodes-add-modal-body');
 				div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.\n' + data;
@@ -25,16 +25,16 @@
 		<div class="modal-content modal-small">
 			<div class="modal-header">
 				<span class="close">&times;</span>
-				<h2>Add a host to PiCluster</h2>
+				<h2>Add a node to PiCluster</h2>
 			</div>
 			<div class="modal-body">
 				<p class="modal-description">
-					Add a new host to PiCluster config file.
+					Add a new node to PiCluster config file.
 				</p>
 				<div id="node_add">
 					<fieldset>
 						<legend><b>Host or IP</b></legend>
-						<input type="text" id="host" name="host" value="">
+						<input type="text" id="node" name="node" value="">
 					</fieldset>
 
 					<div id="submit_button_div">

--- a/web/nodes-manage.html
+++ b/web/nodes-manage.html
@@ -1,0 +1,130 @@
+<html>
+<head>
+	<script src="/assets/jquery.min.js"></script>
+	<link rel="stylesheet" href="/assets/jquery-ui.css">
+	<script src="/assets/jquery-ui.js"></script>
+  <link rel="stylesheet" href="/assets/picluster-iframe.css">
+	<script>
+		var option;
+
+		$.get("/nodes?token=" + parent.token, function(data) {
+			for (var i in data.nodes) {
+				option += '<option value="' + data.nodes[i] + '">' + data.nodes[i] + '</option>';
+			}
+			$('#node_list').append(option);
+		});
+
+		function exec() {
+			var node_list = document.getElementById("node_list");
+			var radio_node_add = $('input[id=radio_node_add]:checked').val();
+			var radio_node_remove = $('input[id=radio_node_remove]:checked').val();
+
+			var path = radio_node_add ? '/addhost'
+				: radio_node_remove ? '/rmhost'
+				: ''
+
+			var node = radio_node_add ? $("#node").val()
+				: radio_node_remove ? node_list.options[node_list.selectedIndex].value
+				: ''
+
+			$.post(path, {
+				token: parent.token,
+				host: node
+			}, function(data) {
+				var div = document.getElementById('nodes-manage-modal-body');
+				div.innerHTML = 'Sent request to the server. Please check the logs and running containers for updated information.<br>' + data;
+			});
+		}
+
+		$(document).ready(function() {
+			$("input[id$='radio_node_add']").click(function() {
+				$(this).is(":checked") ? $("#node").show() : '';
+				$(this).is(":checked") ? $("#node_list").hide() : '';
+			})
+
+			$("input[id$='radio_node_remove']").click(function() {
+				$(this).is(":checked") ? $("#node").hide() : '';
+				$(this).is(":checked") ? $("#node_list").show() : '';
+			})
+
+			$("#node").hide();
+			$("#node_list").hide();
+		});
+	</script>
+</head>
+
+<body>
+	<div id="modal_container" class="modal">
+		<div class="modal-content modal-small">
+			<div class="modal-header">
+				<span class="close">&times;</span>
+				<h2>Add a node to PiCluster</h2>
+			</div>
+
+			<div class="modal-body">
+				<p class="modal-description">
+					Add or remove a node to PiCluster config file.
+				</p>
+
+				<div id="node_add">
+					<fieldset>
+						<legend><b>Add</b></legend>
+						<input type="radio" name="nodes_radio" id="radio_node_add">
+						<label for="radio_node_add">Host/IP</label>
+						<input type="text" id="node" name="node" value="">
+					</fieldset>
+				</div>
+
+				<div id="node_remove">
+					<fieldset>
+						<legend><b>Remove</b></legend>
+						<input type="radio" name="nodes_radio" id="radio_node_remove">
+						<label for="radio_node_remove">Node</label>
+						<select name="node_list" id="node_list"></select>
+					</fieldset>
+				</div>
+
+				<div id="submit_button_div">
+					<button id="submit_button">Submit</button>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div id="output" class="modal">
+		<div class="modal-content modal-small">
+			<div class="modal-header">
+				<span class="close">&times;</span>
+				<h2>Command Output</h2>
+			</div>
+			<div id="nodes-manage-modal-body" class="modal-body">
+				Please wait.
+			</div>
+		</div>
+	</div>
+	</p>
+
+	<script>
+	var span = document.getElementsByClassName("close")[0];
+	var modal = document.getElementById('modal_container');
+	var output_modal = document.getElementById('output');
+	var output_span = document.getElementsByClassName("close")[1];
+	var submit_button = document.getElementById("submit_button");
+
+	span.onclick = function() {
+		modal.style.display = "none";
+	}
+
+	output_span.onclick = function() {
+		output_modal.style.display = "none";
+	}
+
+	submit_button.onclick = function() {
+		modal.style.display = "none";
+		output_modal.style.display = "block";
+		exec();
+	}
+
+	modal.style.display = "block";
+	</script>
+</html>

--- a/web/webconsole.js
+++ b/web/webconsole.js
@@ -1120,6 +1120,9 @@ app.get('/nodes-add.html', (req, res) => {
 app.get('/nodes-remove.html', (req, res) => {
   res.sendFile(__dirname + '/nodes-remove.html');
 });
+app.get('/nodes-manage.html', (req, res) => {
+  res.sendFile(__dirname + '/nodes-manage.html');
+});
 app.get('/rsyslog.html', (req, res) => {
   res.sendFile(__dirname + '/rsyslog.html');
 });


### PR DESCRIPTION
This PR resolves the problem described in issue #112. Along with the minor UI bug fix, I've merged the add node and remove node into a single manage node HTML.

The modal allow only the selection of add **or** remove, and hides the respective input field to prevent any mix up. The links for add node and remove node have been removed from the nav menu, but the HTML files and webconsole routes still exist until feature is fully accepted.